### PR TITLE
fix: make Linux open target patch robust

### DIFF
--- a/scripts/lib/upstream-patches.mjs
+++ b/scripts/lib/upstream-patches.mjs
@@ -10,11 +10,11 @@ const linuxOpenTargetDefinitions = openCommandName => [
   "__codexLinuxOpenTargetNvimArgs=(e,t)=>t?[`+call cursor(${t.line},${t.column})`,e]:[e]",
   "__codexLinuxOpenTargetNvimCommand=(e,n,r)=>`${t.En(e)} ${t.Tn(__codexLinuxOpenTargetNvimArgs(n,r))}`",
   `__codexLinuxOpenTargetRunNvim=async({command:e,path:t,location:n})=>{let r=__codexLinuxOpenTargetTerminal();if(!r)throw Error(\`No terminal emulator found for Neovim\`);await ${openCommandName}(r.command,r.args(__codexLinuxOpenTargetNvimCommand(e,t,n)))}`,
-  "__codexLinuxVSCode=jl({id:`vscode`,label:`VS Code`,icon:`apps/vscode.png`,kind:`editor`,linux:{detect:()=>W(`code`),args:__codexLinuxOpenTargetGotoArgs}})",
-  "__codexLinuxVSCodeInsiders=jl({id:`vscodeInsiders`,label:`VS Code Insiders`,icon:`apps/vscode-insiders.png`,kind:`editor`,linux:{detect:()=>W(`code-insiders`),args:__codexLinuxOpenTargetGotoArgs}})",
-  "__codexLinuxCursor=jl({id:`cursor`,label:`Cursor`,icon:`apps/cursor.png`,kind:`editor`,linux:{detect:()=>W(`cursor`),args:__codexLinuxOpenTargetGotoArgs}})",
-  "__codexLinuxZed=jl({id:`zed`,label:`Zed`,icon:`apps/zed.png`,kind:`editor`,linux:{detect:()=>W(`zed`),args:__codexLinuxOpenTargetColonArgs}})",
-  "__codexLinuxNvim=jl({id:`nvim`,label:`Neovim`,icon:`apps/terminal.png`,kind:`editor`,linux:{detect:()=>W(`nvim`),args:__codexLinuxOpenTargetNvimArgs,open:__codexLinuxOpenTargetRunNvim}})"
+  "__codexLinuxVSCode={id:`vscode`,platforms:{linux:{label:`VS Code`,icon:`apps/vscode.png`,kind:`editor`,detect:()=>W(`code`),args:__codexLinuxOpenTargetGotoArgs}}}",
+  "__codexLinuxVSCodeInsiders={id:`vscodeInsiders`,platforms:{linux:{label:`VS Code Insiders`,icon:`apps/vscode-insiders.png`,kind:`editor`,detect:()=>W(`code-insiders`),args:__codexLinuxOpenTargetGotoArgs}}}",
+  "__codexLinuxCursor={id:`cursor`,platforms:{linux:{label:`Cursor`,icon:`apps/cursor.png`,kind:`editor`,detect:()=>W(`cursor`),args:__codexLinuxOpenTargetGotoArgs}}}",
+  "__codexLinuxZed={id:`zed`,platforms:{linux:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:()=>W(`zed`),args:__codexLinuxOpenTargetColonArgs}}}",
+  "__codexLinuxNvim={id:`nvim`,platforms:{linux:{label:`Neovim`,icon:`apps/terminal.png`,kind:`editor`,detect:()=>W(`nvim`),args:__codexLinuxOpenTargetNvimArgs,open:__codexLinuxOpenTargetRunNvim}}}"
 ].join(",");
 
 export async function patchUpstreamApp(stageAppDir) {
@@ -55,7 +55,16 @@ export function patchLinuxOpenTargetsSource(source) {
     patched = replaceOnce(patched, openTargetMapAnchor, patchedOpenTargetMap);
   }
 
+  patched = patchOpenTargetPlatformLookup(patched);
+
   return patched;
+}
+
+function patchOpenTargetPlatformLookup(source) {
+  return source.replaceAll(
+    "let n=t.platforms[e];return n",
+    "let n=t.platforms?.[e];return n"
+  );
 }
 
 function findOpenTargetRegistry(source) {

--- a/test/upstream-patches.test.mjs
+++ b/test/upstream-patches.test.mjs
@@ -15,10 +15,10 @@ test("patchLinuxOpenTargetsSource adds Linux editor targets and exposes app path
 
   const patched = patchLinuxOpenTargetsSource(source);
 
-  assert.match(patched, /__codexLinuxVSCode=jl/);
-  assert.match(patched, /__codexLinuxCursor=jl/);
-  assert.match(patched, /__codexLinuxZed=jl/);
-  assert.match(patched, /__codexLinuxNvim=jl/);
+  assert.match(patched, /__codexLinuxVSCode=\{id:`vscode`,platforms:\{linux:/);
+  assert.match(patched, /__codexLinuxCursor=\{id:`cursor`,platforms:\{linux:/);
+  assert.match(patched, /__codexLinuxZed=\{id:`zed`,platforms:\{linux:/);
+  assert.match(patched, /__codexLinuxNvim=\{id:`nvim`,platforms:\{linux:/);
   assert.match(
     patched,
     /var wd=\[__codexLinuxVSCode,__codexLinuxVSCodeInsiders,__codexLinuxCursor,__codexLinuxZed,__codexLinuxNvim,nd,id/
@@ -31,6 +31,8 @@ test("patchLinuxOpenTargetsSource adds Linux editor targets and exposes app path
     patched,
     /appPath:process\.platform===`linux`&&r===`editor`&&s\.has\(e\)\?Ld\(\)\.get\(e\)\?\?null:null/
   );
+  assert.match(patched, /let n=t\.platforms\?\.\[e\];return n/);
+  assert.doesNotMatch(patched, /let n=t\.platforms\[e\];return n/);
 });
 
 test("patchLinuxOpenTargetsSource is idempotent for target definitions", () => {
@@ -43,7 +45,7 @@ test("patchLinuxOpenTargetsSource is idempotent for target definitions", () => {
   const patched = patchLinuxOpenTargetsSource(source);
   const repatched = patchLinuxOpenTargetsSource(patched);
 
-  assert.equal(repatched.match(/__codexLinuxVSCode=jl/g).length, 1);
+  assert.equal(repatched.match(/__codexLinuxVSCode=\{id:`vscode`,platforms:\{linux:/g).length, 1);
 });
 
 test("patchLinuxOpenTargetsSource accepts alternate minified logger names", () => {
@@ -59,4 +61,16 @@ test("patchLinuxOpenTargetsSource accepts alternate minified logger names", () =
     patched,
     /var Cd=\[__codexLinuxVSCode,__codexLinuxVSCodeInsiders,__codexLinuxCursor,__codexLinuxZed,__codexLinuxNvim,td,rd/
   );
+});
+
+test("patchLinuxOpenTargetsSource tolerates targets without platform maps", () => {
+  const source = [
+    "var wd=[nd,id],Td=t.kr(`open-in-targets`);function Ed(e){return wd.flatMap(t=>{let n=t.platforms[e];return n?[{id:t.id,...n}]:[]})}",
+    "async function Fd(e,t,n,r,i,a,o){let s={args:()=>[],env:()=>({})},c=`open`;await ol(c,s.args(t,r,i,a,o),{env:s.env?.()})}",
+    "targets:[...o.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:s.has(e),default:c===e||void 0})),...p]"
+  ].join(";");
+
+  const patched = patchLinuxOpenTargetsSource(source);
+
+  assert.match(patched, /let n=t\.platforms\?\.\[e\];return n/);
 });


### PR DESCRIPTION
## Summary

Fixes #1.

This updates the Linux open-target upstream patch to avoid depending on an unstable minified helper name and to tolerate registry entries that do not expose a platform map.

## Root Cause

The Linux patch currently injects editor targets through a minified upstream helper:

```js
__codexLinuxVSCode = jl({ ... })
```

In the current upstream bundle, that minified name is no longer a stable way to create open-target records. The generated registry can therefore contain entries without a valid `platforms` object. During startup, the app then evaluates:

```js
t.platforms[e]
```

with `e === "linux"`, which throws:

```text
Cannot read properties of undefined (reading 'linux')
```

## Changes

- Emit Linux open-target records directly as `{ id, platforms: { linux: ... } }` objects instead of calling the minified helper.
- Patch the minified platform lookup to use optional chaining:

```diff
- let n=t.platforms[e];return n
+ let n=t.platforms?.[e];return n
```

- Add tests covering the defensive platform lookup and updated injected target shape.

## Validation

```text
npm test
```

passes locally with 48/48 tests.
