### PR TITLE
Patch upstream source to disable window transparency update #2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@electron/asar": "4.1.0",
         "@electron/rebuild": "4.0.3",
+        "acorn": "8.15.0",
         "electron": "42.1.0",
         "electron-builder": "26.8.1",
         "ws": "8.20.0"
@@ -950,6 +951,19 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@electron/asar": "4.1.0",
     "@electron/rebuild": "4.0.3",
+    "acorn": "8.15.0",
     "electron": "42.1.0",
     "electron-builder": "26.8.1",
     "ws": "8.20.0"

--- a/scripts/lib/build.mjs
+++ b/scripts/lib/build.mjs
@@ -363,43 +363,106 @@ export async function patchBetterSqlite3NativeSource(packageDir) {
   const entrypointPath = path.join(packageDir, "src", "better_sqlite3.cpp");
 
   let macros = await fs.readFile(macrosPath, "utf8");
-  macros = replaceOnce(
-    macros,
-    "#define OnlyIsolate info.GetIsolate()\n#define OnlyContext isolate->GetCurrentContext()\n#define OnlyAddon static_cast<Addon*>(info.Data().As<v8::External>()->Value())",
-    [
-      "#define OnlyIsolate info.GetIsolate()",
-      "#define OnlyContext isolate->GetCurrentContext()",
-      "",
-      "// Electron 42 enables V8 external pointer sandboxing; v8::External pointers need tags.",
-      "// See V8's v8-external.h kExternalPointerTypeTagDefault notes.",
-      "#if defined(V8_ENABLE_SANDBOX)",
-      "#define BETTER_SQLITE3_EXTERNAL_NEW(isolate, value) v8::External::New(isolate, value, v8::kExternalPointerTypeTagDefault)",
-      "#define BETTER_SQLITE3_EXTERNAL_VALUE(external) (external)->Value(v8::kExternalPointerTypeTagDefault)",
-      "#else",
-      "#define BETTER_SQLITE3_EXTERNAL_NEW(isolate, value) v8::External::New(isolate, value)",
-      "#define BETTER_SQLITE3_EXTERNAL_VALUE(external) (external)->Value()",
-      "#endif",
-      "",
-      "#define OnlyAddon static_cast<Addon*>(BETTER_SQLITE3_EXTERNAL_VALUE(info.Data().As<v8::External>()))"
-    ].join("\n")
-  );
+  macros = patchBetterSqlite3ExternalPointerMacros(macros);
   await fs.writeFile(macrosPath, macros);
 
   let entrypoint = await fs.readFile(entrypointPath, "utf8");
-  entrypoint = replaceOnce(
-    entrypoint,
-    "v8::Local<v8::External> data = v8::External::New(isolate, addon);",
-    "v8::Local<v8::External> data = BETTER_SQLITE3_EXTERNAL_NEW(isolate, addon);"
-  );
+  entrypoint = patchBetterSqlite3ExternalPointerEntrypoint(entrypoint);
   await fs.writeFile(entrypointPath, entrypoint);
 
   let helpers = await fs.readFile(helpersPath, "utf8");
-  helpers = replaceOnce(
-    helpers,
+  helpers = patchBetterSqlite3SetNativeDataProperty(helpers);
+  await fs.writeFile(helpersPath, helpers);
+}
+
+function patchBetterSqlite3ExternalPointerMacros(source) {
+  if (source.includes("#define BETTER_SQLITE3_EXTERNAL_NEW")) {
+    return source;
+  }
+
+  const externalPointerMacros = [
+    "// Electron 42 enables V8 external pointer sandboxing; v8::External pointers need tags.",
+    "// See V8's v8-external.h kExternalPointerTypeTagDefault notes.",
+    "#if defined(V8_ENABLE_SANDBOX)",
+    "#define BETTER_SQLITE3_EXTERNAL_NEW(isolate, value) v8::External::New(isolate, value, v8::kExternalPointerTypeTagDefault)",
+    "#define BETTER_SQLITE3_EXTERNAL_VALUE(external) (external)->Value(v8::kExternalPointerTypeTagDefault)",
+    "#else",
+    "#define BETTER_SQLITE3_EXTERNAL_NEW(isolate, value) v8::External::New(isolate, value)",
+    "#define BETTER_SQLITE3_EXTERNAL_VALUE(external) (external)->Value()",
+    "#endif"
+  ].join("\n");
+
+  const onlyAddon = "#define OnlyAddon static_cast<Addon*>(BETTER_SQLITE3_EXTERNAL_VALUE(info.Data().As<v8::External>()))";
+  const legacyAnchor = [
+    "#define OnlyIsolate info.GetIsolate()",
+    "#define OnlyContext isolate->GetCurrentContext()",
+    "#define OnlyAddon static_cast<Addon*>(info.Data().As<v8::External>()->Value())"
+  ].join("\n");
+  const currentAnchor = [
+    "#if defined(NODE_MODULE_VERSION) && NODE_MODULE_VERSION >= 146",
+    "#define EXTERNAL_NEW(isolate, value) v8::External::New((isolate), (value), 0)",
+    "#define EXTERNAL_VALUE(value) (value)->Value(0)",
+    "#else",
+    "#define EXTERNAL_NEW(isolate, value) v8::External::New((isolate), (value))",
+    "#define EXTERNAL_VALUE(value) (value)->Value()",
+    "#endif",
+    "#define OnlyAddon static_cast<Addon*>(EXTERNAL_VALUE(info.Data().As<v8::External>()))"
+  ].join("\n");
+
+  if (source.includes(legacyAnchor)) {
+    return replaceOnce(
+      source,
+      legacyAnchor,
+      [
+        "#define OnlyIsolate info.GetIsolate()",
+        "#define OnlyContext isolate->GetCurrentContext()",
+        "",
+        externalPointerMacros,
+        "",
+        onlyAddon
+      ].join("\n")
+    );
+  }
+
+  if (source.includes(currentAnchor)) {
+    return replaceOnce(source, currentAnchor, [externalPointerMacros, onlyAddon].join("\n"));
+  }
+
+  throw new Error("Unable to patch better-sqlite3 external pointer macros; unknown source shape");
+}
+
+function patchBetterSqlite3ExternalPointerEntrypoint(source) {
+  const replacement = "v8::Local<v8::External> data = BETTER_SQLITE3_EXTERNAL_NEW(isolate, addon);";
+
+  if (source.includes(replacement)) {
+    return source;
+  }
+
+  if (source.includes("v8::Local<v8::External> data = EXTERNAL_NEW(isolate, addon);")) {
+    return replaceOnce(
+      source,
+      "v8::Local<v8::External> data = EXTERNAL_NEW(isolate, addon);",
+      replacement
+    );
+  }
+
+  return replaceOnce(
+    source,
+    "v8::Local<v8::External> data = v8::External::New(isolate, addon);",
+    replacement
+  );
+}
+
+function patchBetterSqlite3SetNativeDataProperty(source) {
+  if (source.includes("\t\tfunc,\n\t\tnullptr,\n\t\tdata")) {
+    return source;
+  }
+
+  return replaceOnce(
+    source,
     "\t\tfunc,\n\t\t0,\n\t\tdata",
     "\t\tfunc,\n\t\tnullptr,\n\t\tdata"
   );
-  await fs.writeFile(helpersPath, helpers);
 }
 
 async function buildLinuxArtifacts({

--- a/scripts/lib/upstream-patches.mjs
+++ b/scripts/lib/upstream-patches.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { parse } from "acorn";
 
 const linuxOpenTargetDefinitions = openCommandName => [
   "var __codexLinuxOpenTargetGotoArgs=(e,t)=>t?[`--goto`,`${e}:${t.line}:${t.column}`]:[e]",
@@ -73,39 +74,306 @@ export function patchDisableTransparencySource(source) {
 }
 
 function patchLinuxWindowBackground(source) {
-  if (
-    /backgroundColor:[A-Za-z_$][\w$]*===`linux`\?\([A-Za-z_$][\w$]*\?[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*\):[A-Za-z_$][\w$]*,backgroundMaterial:null/.test(source)
-  ) {
+  const patch = findLinuxWindowBackgroundPatch(source);
+
+  if (patch?.status === "patched") {
     return source;
   }
 
-  const match =
-    source.match(
-      /function (?<helper>[A-Za-z_$][\w$]*)\(\{platform:(?<platform>[A-Za-z_$][\w$]*),appearance:(?<appearance>[A-Za-z_$][\w$]*),opaqueWindow(?:sEnabled|SurfaceEnabled):(?<opaque>[A-Za-z_$][\w$]*),prefersDarkColors:(?<prefersDark>[A-Za-z_$][\w$]*)\}\)\{return \k<opaque>&&!(?<special>[A-Za-z_$][\w$]*)\(\k<appearance>\)&&\(\k<platform>===`darwin`\|\|\k<platform>===`win32`\)\?\{backgroundColor:\k<prefersDark>\?(?<darkColor>[A-Za-z_$][\w$]*):(?<lightColor>[A-Za-z_$][\w$]*),backgroundMaterial:\k<platform>===`win32`\?`none`:null\}:\k<platform>===`win32`&&!\k<special>\(\k<appearance>\)\?\{backgroundColor:(?<winColor>[A-Za-z_$][\w$]*),backgroundMaterial:`mica`\}:\{backgroundColor:(?<fallbackColor>[A-Za-z_$][\w$]*),backgroundMaterial:null\}\}/
-    ) ??
-    source.match(
-      /function (?<helper>[A-Za-z_$][\w$]*)\(\{platform:(?<platform>[A-Za-z_$][\w$]*),appearance:(?<appearance>[A-Za-z_$][\w$]*),opaqueWindow(?:sEnabled|SurfaceEnabled):(?<opaque>[A-Za-z_$][\w$]*),prefersDarkColors:(?<prefersDark>[A-Za-z_$][\w$]*)\}\)\{return \k<opaque>\?\{backgroundColor:\k<prefersDark>\?(?<darkColor>[A-Za-z_$][\w$]*):(?<lightColor>[A-Za-z_$][\w$]*),backgroundMaterial:\k<platform>===`win32`\?`none`:null\}:\k<platform>===`win32`&&!(?<special>[A-Za-z_$][\w$]*)\(\k<appearance>\)\?\{backgroundColor:(?<winColor>[A-Za-z_$][\w$]*),backgroundMaterial:`mica`\}:\{backgroundColor:(?<fallbackColor>[A-Za-z_$][\w$]*),backgroundMaterial:null\}\}/
-    );
-
-  if (!match) {
+  if (!patch) {
     throw new Error("Unable to apply upstream patch; missing window background helper");
   }
 
-  const anchor = match[0];
-  const {
-    platform: platformVar,
-    prefersDark: prefersDarkVar,
-    darkColor: darkColorVar,
-    lightColor: lightColorVar,
-    fallbackColor: fallbackColorVar
-  } = match.groups;
-  const fallback = `{backgroundColor:${fallbackColorVar},backgroundMaterial:null}`;
-  const replacement = anchor.replace(
-    fallback,
-    `{backgroundColor:${platformVar}===\`linux\`?(${prefersDarkVar}?${darkColorVar}:${lightColorVar}):${fallbackColorVar},backgroundMaterial:null}`
-  );
+  return `${source.slice(0, patch.start)}${patch.replacement}${source.slice(patch.end)}`;
+}
 
-  return replaceOnce(source, anchor, replacement);
+function findLinuxWindowBackgroundPatch(source) {
+  const ast = parseJavaScript(source);
+  const candidates = [];
+  let patchedCandidates = 0;
+
+  walkAst(ast, node => {
+    if (!isFunctionNode(node)) {
+      return;
+    }
+
+    const patch = linuxWindowBackgroundPatchForFunction(source, node);
+
+    if (patch?.status === "patched") {
+      patchedCandidates++;
+      return;
+    }
+
+    if (patch) {
+      candidates.push(patch);
+    }
+  });
+
+  if (candidates.length > 1) {
+    throw new Error("Unable to apply upstream patch; ambiguous window background helper");
+  }
+
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  if (patchedCandidates > 0) {
+    return { status: "patched" };
+  }
+
+  return null;
+}
+
+function linuxWindowBackgroundPatchForFunction(source, node) {
+  const bindings = objectPatternBindings(node.params[0]);
+  const platformVar = bindings.platform;
+  const prefersDarkVar = bindings.prefersDarkColors;
+
+  if (
+    !platformVar ||
+    !bindings.appearance ||
+    !prefersDarkVar ||
+    !(bindings.opaqueWindowsEnabled || bindings.opaqueWindowSurfaceEnabled)
+  ) {
+    return null;
+  }
+
+  const returnExpression = returnExpressionForFunction(node);
+
+  if (!returnExpression) {
+    return null;
+  }
+
+  const objects = [];
+  walkAst(returnExpression, child => {
+    if (child.type === "ObjectExpression") {
+      objects.push(child);
+    }
+  });
+
+  const palette = objects.map(object => backgroundPaletteForObject(object, platformVar, prefersDarkVar)).find(Boolean);
+
+  if (!palette) {
+    return null;
+  }
+
+  for (const object of objects) {
+    const backgroundColor = getObjectProperty(object, "backgroundColor");
+    const backgroundMaterial = getObjectProperty(object, "backgroundMaterial");
+
+    if (!backgroundColor || !backgroundMaterial || !isNullLiteral(backgroundMaterial.value)) {
+      continue;
+    }
+
+    if (isLinuxConditional(backgroundColor.value, platformVar)) {
+      return { status: "patched" };
+    }
+
+    const fallbackSource = source.slice(backgroundColor.value.start, backgroundColor.value.end);
+    const darkSource = source.slice(palette.dark.start, palette.dark.end);
+    const lightSource = source.slice(palette.light.start, palette.light.end);
+
+    return {
+      status: "patch",
+      start: backgroundColor.value.start,
+      end: backgroundColor.value.end,
+      replacement: `${platformVar}===\`linux\`?(${prefersDarkVar}?${darkSource}:${lightSource}):${fallbackSource}`
+    };
+  }
+
+  return null;
+}
+
+function backgroundPaletteForObject(object, platformVar, prefersDarkVar) {
+  const backgroundColor = getObjectProperty(object, "backgroundColor");
+  const backgroundMaterial = getObjectProperty(object, "backgroundMaterial");
+
+  if (
+    !backgroundColor ||
+    !backgroundMaterial ||
+    backgroundColor.value.type !== "ConditionalExpression" ||
+    !isIdentifierNamed(backgroundColor.value.test, prefersDarkVar) ||
+    !isWin32BackgroundMaterial(backgroundMaterial.value, platformVar)
+  ) {
+    return null;
+  }
+
+  return {
+    dark: backgroundColor.value.consequent,
+    light: backgroundColor.value.alternate
+  };
+}
+
+function parseJavaScript(source) {
+  try {
+    return parse(source, {
+      ecmaVersion: "latest",
+      sourceType: "script",
+      allowHashBang: true
+    });
+  } catch {
+    return parse(source, {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      allowHashBang: true
+    });
+  }
+}
+
+function walkAst(root, visit) {
+  const stack = [root];
+
+  while (stack.length > 0) {
+    const node = stack.pop();
+
+    if (!isNode(node)) {
+      continue;
+    }
+
+    visit(node);
+
+    for (const key of Object.keys(node)) {
+      if (key === "start" || key === "end" || key === "loc" || key === "range") {
+        continue;
+      }
+
+      const value = node[key];
+
+      if (Array.isArray(value)) {
+        for (let index = value.length - 1; index >= 0; index--) {
+          if (isNode(value[index])) {
+            stack.push(value[index]);
+          }
+        }
+      } else if (isNode(value)) {
+        stack.push(value);
+      }
+    }
+  }
+}
+
+function isNode(value) {
+  return Boolean(value && typeof value.type === "string");
+}
+
+function isFunctionNode(node) {
+  return (
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression"
+  );
+}
+
+function objectPatternBindings(pattern) {
+  if (pattern?.type !== "ObjectPattern") {
+    return {};
+  }
+
+  const bindings = {};
+
+  for (const property of pattern.properties) {
+    if (property.type !== "Property" || property.computed) {
+      continue;
+    }
+
+    const key = propertyName(property.key);
+    const local = patternLocalName(property.value);
+
+    if (key && local) {
+      bindings[key] = local;
+    }
+  }
+
+  return bindings;
+}
+
+function patternLocalName(value) {
+  if (value.type === "Identifier") {
+    return value.name;
+  }
+
+  if (value.type === "AssignmentPattern" && value.left.type === "Identifier") {
+    return value.left.name;
+  }
+
+  return null;
+}
+
+function returnExpressionForFunction(node) {
+  if (node.type === "ArrowFunctionExpression" && node.expression) {
+    return node.body;
+  }
+
+  if (node.body?.type !== "BlockStatement") {
+    return null;
+  }
+
+  return node.body.body.find(statement => statement.type === "ReturnStatement")?.argument ?? null;
+}
+
+function getObjectProperty(object, name) {
+  return object.properties.find(property => {
+    if (property.type !== "Property" || property.computed) {
+      return false;
+    }
+
+    return propertyName(property.key) === name;
+  });
+}
+
+function propertyName(key) {
+  if (key.type === "Identifier") {
+    return key.name;
+  }
+
+  if (key.type === "Literal" && typeof key.value === "string") {
+    return key.value;
+  }
+
+  return null;
+}
+
+function isNullLiteral(node) {
+  return node.type === "Literal" && node.value === null;
+}
+
+function isIdentifierNamed(node, name) {
+  return node.type === "Identifier" && node.name === name;
+}
+
+function isWin32BackgroundMaterial(node, platformVar) {
+  return (
+    node.type === "ConditionalExpression" &&
+    isPlatformEquals(node.test, platformVar, "win32") &&
+    isStringLiteral(node.consequent, "none") &&
+    isNullLiteral(node.alternate)
+  );
+}
+
+function isLinuxConditional(node, platformVar) {
+  return node.type === "ConditionalExpression" && isPlatformEquals(node.test, platformVar, "linux");
+}
+
+function isPlatformEquals(node, platformVar, platform) {
+  return (
+    node.type === "BinaryExpression" &&
+    node.operator === "===" &&
+    ((isIdentifierNamed(node.left, platformVar) && isStringLiteral(node.right, platform)) ||
+      (isStringLiteral(node.left, platform) && isIdentifierNamed(node.right, platformVar)))
+  );
+}
+
+function isStringLiteral(node, value) {
+  if (node.type === "Literal") {
+    return node.value === value;
+  }
+
+  return (
+    node.type === "TemplateLiteral" &&
+    node.expressions.length === 0 &&
+    node.quasis.length === 1 &&
+    node.quasis[0].value.cooked === value
+  );
 }
 
 function patchLinuxWindowTransparency(source) {

--- a/scripts/lib/upstream-patches.mjs
+++ b/scripts/lib/upstream-patches.mjs
@@ -79,27 +79,26 @@ function patchLinuxWindowBackground(source) {
     return source;
   }
 
-  const match = source.match(
-    /function ([A-Za-z_$][\w$]*)\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return \4&&!([A-Za-z_$][\w$]*)\(\3\)&&\(\2===`darwin`\|\|\2===`win32`\)\?\{backgroundColor:\5\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),backgroundMaterial:\2===`win32`\?`none`:null\}:\2===`win32`&&!\6\(\3\)\?\{backgroundColor:([A-Za-z_$][\w$]*),backgroundMaterial:`mica`\}:\{backgroundColor:([A-Za-z_$][\w$]*),backgroundMaterial:null\}\}/
-  );
+  const match =
+    source.match(
+      /function (?<helper>[A-Za-z_$][\w$]*)\(\{platform:(?<platform>[A-Za-z_$][\w$]*),appearance:(?<appearance>[A-Za-z_$][\w$]*),opaqueWindow(?:sEnabled|SurfaceEnabled):(?<opaque>[A-Za-z_$][\w$]*),prefersDarkColors:(?<prefersDark>[A-Za-z_$][\w$]*)\}\)\{return \k<opaque>&&!(?<special>[A-Za-z_$][\w$]*)\(\k<appearance>\)&&\(\k<platform>===`darwin`\|\|\k<platform>===`win32`\)\?\{backgroundColor:\k<prefersDark>\?(?<darkColor>[A-Za-z_$][\w$]*):(?<lightColor>[A-Za-z_$][\w$]*),backgroundMaterial:\k<platform>===`win32`\?`none`:null\}:\k<platform>===`win32`&&!\k<special>\(\k<appearance>\)\?\{backgroundColor:(?<winColor>[A-Za-z_$][\w$]*),backgroundMaterial:`mica`\}:\{backgroundColor:(?<fallbackColor>[A-Za-z_$][\w$]*),backgroundMaterial:null\}\}/
+    ) ??
+    source.match(
+      /function (?<helper>[A-Za-z_$][\w$]*)\(\{platform:(?<platform>[A-Za-z_$][\w$]*),appearance:(?<appearance>[A-Za-z_$][\w$]*),opaqueWindow(?:sEnabled|SurfaceEnabled):(?<opaque>[A-Za-z_$][\w$]*),prefersDarkColors:(?<prefersDark>[A-Za-z_$][\w$]*)\}\)\{return \k<opaque>\?\{backgroundColor:\k<prefersDark>\?(?<darkColor>[A-Za-z_$][\w$]*):(?<lightColor>[A-Za-z_$][\w$]*),backgroundMaterial:\k<platform>===`win32`\?`none`:null\}:\k<platform>===`win32`&&!(?<special>[A-Za-z_$][\w$]*)\(\k<appearance>\)\?\{backgroundColor:(?<winColor>[A-Za-z_$][\w$]*),backgroundMaterial:`mica`\}:\{backgroundColor:(?<fallbackColor>[A-Za-z_$][\w$]*),backgroundMaterial:null\}\}/
+    );
 
   if (!match) {
     throw new Error("Unable to apply upstream patch; missing window background helper");
   }
 
-  const [
-    anchor,
-    ,
-    platformVar,
-    ,
-    ,
-    prefersDarkVar,
-    ,
-    darkColorVar,
-    lightColorVar,
-    ,
-    fallbackColorVar
-  ] = match;
+  const anchor = match[0];
+  const {
+    platform: platformVar,
+    prefersDark: prefersDarkVar,
+    darkColor: darkColorVar,
+    lightColor: lightColorVar,
+    fallbackColor: fallbackColorVar
+  } = match.groups;
   const fallback = `{backgroundColor:${fallbackColorVar},backgroundMaterial:null}`;
   const replacement = anchor.replace(
     fallback,

--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -139,3 +139,58 @@ test("patchBetterSqlite3NativeSource updates V8 external pointer calls", async (
     /\t\tnullptr,\n\t\tdata/
   );
 });
+
+test("patchBetterSqlite3NativeSource updates newer better-sqlite3 external helpers", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-app-linux-native-test-"));
+  const packageDir = path.join(root, "better-sqlite3");
+  const utilDir = path.join(packageDir, "src", "util");
+  const srcDir = path.join(packageDir, "src");
+
+  await fs.mkdir(utilDir, { recursive: true });
+  await fs.writeFile(
+    path.join(utilDir, "macros.cpp"),
+    [
+      "#define OnlyIsolate info.GetIsolate()",
+      "#define OnlyContext isolate->GetCurrentContext()",
+      "#if defined(NODE_MODULE_VERSION) && NODE_MODULE_VERSION >= 146",
+      "#define EXTERNAL_NEW(isolate, value) v8::External::New((isolate), (value), 0)",
+      "#define EXTERNAL_VALUE(value) (value)->Value(0)",
+      "#else",
+      "#define EXTERNAL_NEW(isolate, value) v8::External::New((isolate), (value))",
+      "#define EXTERNAL_VALUE(value) (value)->Value()",
+      "#endif",
+      "#define OnlyAddon static_cast<Addon*>(EXTERNAL_VALUE(info.Data().As<v8::External>()))",
+      "#define UseAddon Addon* addon = OnlyAddon"
+    ].join("\n")
+  );
+  await fs.writeFile(
+    path.join(utilDir, "helpers.cpp"),
+    [
+      "recv->InstanceTemplate()->SetNativeDataProperty(",
+      "\t\tInternalizedFromLatin1(isolate, name),",
+      "\t\tfunc,",
+      "\t\tnullptr,",
+      "\t\tdata",
+      "\t);"
+    ].join("\n")
+  );
+  await fs.writeFile(
+    path.join(srcDir, "better_sqlite3.cpp"),
+    "v8::Local<v8::External> data = EXTERNAL_NEW(isolate, addon);"
+  );
+
+  await patchBetterSqlite3NativeSource(packageDir);
+
+  assert.match(
+    await fs.readFile(path.join(utilDir, "macros.cpp"), "utf8"),
+    /BETTER_SQLITE3_EXTERNAL_VALUE\(info\.Data\(\)\.As<v8::External>\(\)\)/
+  );
+  assert.match(
+    await fs.readFile(path.join(srcDir, "better_sqlite3.cpp"), "utf8"),
+    /BETTER_SQLITE3_EXTERNAL_NEW\(isolate, addon\)/
+  );
+  assert.match(
+    await fs.readFile(path.join(utilDir, "helpers.cpp"), "utf8"),
+    /\t\tnullptr,\n\t\tdata/
+  );
+});

--- a/test/launcher-wrapper.test.mjs
+++ b/test/launcher-wrapper.test.mjs
@@ -171,7 +171,7 @@ test("launcher reports package version without starting Electron", async () => {
     child.stdout.on("data", chunk => stdout.push(chunk));
     child.stderr.on("data", chunk => stderr.push(chunk));
     child.on("error", reject);
-    child.on("exit", code => {
+    child.on("close", code => {
       if (code === 0) {
         resolve({
           stdout: Buffer.concat(stdout).toString("utf8"),
@@ -216,7 +216,7 @@ test("launcher help advertises plusplus command", async () => {
     child.stdout.on("data", chunk => stdout.push(chunk));
     child.stderr.on("data", chunk => stderr.push(chunk));
     child.on("error", reject);
-    child.on("exit", code => {
+    child.on("close", code => {
       if (code === 0) {
         resolve({
           stdout: Buffer.concat(stdout).toString("utf8"),
@@ -252,7 +252,7 @@ test("launcher plusplus help does not resolve desktop package", async () => {
     child.stdout.on("data", chunk => stdout.push(chunk));
     child.stderr.on("data", chunk => stderr.push(chunk));
     child.on("error", reject);
-    child.on("exit", code => {
+    child.on("close", code => {
       if (code === 0) {
         resolve({
           stdout: Buffer.concat(stdout).toString("utf8"),
@@ -348,7 +348,7 @@ fs.writeFileSync(${JSON.stringify(argsPath)}, JSON.stringify(process.argv.slice(
     child.stdout.on("data", chunk => stdout.push(chunk));
     child.stderr.on("data", chunk => stderr.push(chunk));
     child.on("error", reject);
-    child.on("exit", code => {
+    child.on("close", code => {
       if (code === 0) {
         resolve({
           stdout: Buffer.concat(stdout).toString("utf8"),

--- a/test/upstream-patches.test.mjs
+++ b/test/upstream-patches.test.mjs
@@ -142,6 +142,23 @@ test("patchDisableTransparencySource accepts opaque window surface helper name",
   assert.match(patched, /transparent:n===`linux`\?!1:a,hasShadow:t/);
 });
 
+test("patchDisableTransparencySource patches background helper by AST shape", () => {
+  const source = [
+    "function skip(kind) { return kind === `avatarOverlay`; }",
+    "function backdrop({ appearance: kind, prefersDarkColors: dark, platform: os, opaqueWindowSurfaceEnabled: opaque }) {",
+    "  return opaque ? { backgroundMaterial: os === `win32` ? `none` : null, backgroundColor: dark ? DARK : LIGHT }",
+    "    : os === `win32` && !skip(kind) ? { backgroundMaterial: `mica`, backgroundColor: WIN }",
+    "    : { backgroundMaterial: null, backgroundColor: FALLBACK };",
+    "}",
+    "function frame({alwaysOnTop:e,hasShadow:t=!0,platform:n,resizable:r,thickFrame:i,transparent:a=!0}){return{frame:!1,transparent:a,hasShadow:t,resizable:r,minimizable:!1,maximizable:!1,fullscreenable:!1,skipTaskbar:!0}}"
+  ].join("\n");
+
+  const patched = patchDisableTransparencySource(source);
+
+  assert.match(patched, /backgroundMaterial: null, backgroundColor: os===`linux`\?\(dark\?DARK:LIGHT\):FALLBACK/);
+  assert.match(patched, /transparent:n===`linux`\?!1:a,hasShadow:t/);
+});
+
 test("patchDisableTransparencySource is idempotent", () => {
   const source = [
     "function A2(e){return e===`avatarOverlay`||e===`browserCommentPopup`}",

--- a/test/upstream-patches.test.mjs
+++ b/test/upstream-patches.test.mjs
@@ -129,6 +129,19 @@ test("patchDisableTransparencySource disables Linux BrowserWindow transparency a
   assert.doesNotMatch(patched, /return\{frame:!1,transparent:a,hasShadow:t/);
 });
 
+test("patchDisableTransparencySource accepts opaque window surface helper name", () => {
+  const source = [
+    "function C6(e){return e===`avatarOverlay`||e===`browserCommentPopup`}",
+    "function k6({platform:e,appearance:t,opaqueWindowSurfaceEnabled:n,prefersDarkColors:r}){return n?{backgroundColor:r?Q3:$3,backgroundMaterial:e===`win32`?`none`:null}:e===`win32`&&!C6(t)?{backgroundColor:Z3,backgroundMaterial:`mica`}:{backgroundColor:Z3,backgroundMaterial:null}}",
+    "function j6({alwaysOnTop:e,hasShadow:t=!0,platform:n,resizable:r,thickFrame:i,transparent:a=!0}){return{frame:!1,transparent:a,hasShadow:t,resizable:r,minimizable:!1,maximizable:!1,fullscreenable:!1,skipTaskbar:!0,...e?{alwaysOnTop:!0}:{},...n===`win32`?{accentColor:!1,roundedCorners:!1,...i==null?{}:{thickFrame:i}}:{},...n===`darwin`?{type:`panel`}:{}}}"
+  ].join(";");
+
+  const patched = patchDisableTransparencySource(source);
+
+  assert.match(patched, /backgroundColor:e===`linux`\?\(r\?Q3:\$3\):Z3,backgroundMaterial:null/);
+  assert.match(patched, /transparent:n===`linux`\?!1:a,hasShadow:t/);
+});
+
 test("patchDisableTransparencySource is idempotent", () => {
   const source = [
     "function A2(e){return e===`avatarOverlay`||e===`browserCommentPopup`}",


### PR DESCRIPTION
For patching window background to turn off transparency we're now using javascript parser (acorn) instead of regex to be more resilient to upstream code changes.

There seems to be some patching failures in better-sqlite patches needed too that needs to be tweaked, so it's done here too.

<img width="1905" height="298" alt="image" src="https://github.com/user-attachments/assets/70e5503c-4712-47e9-bb92-1432557ee055" />
