### PR TITLE
ci: add upstream canary smoke gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,70 @@ jobs:
           echo "prod_version=$(jq -r '.channels.prod.packageVersion' dist/release-state.json)" >> "$GITHUB_OUTPUT"
           echo "beta_version=$(jq -r '.channels.beta.packageVersion' dist/release-state.json)" >> "$GITHUB_OUTPUT"
 
-  publish-prod:
+  canary:
     needs: preflight
+    if: github.event.inputs.force == 'true' || needs.preflight.outputs.prod_outdated == 'true' || needs.preflight.outputs.beta_outdated == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      NPM_PACKAGE_NAME: "codex-app-linux"
+      CODEX_RELEASE_REPO: "${{ github.repository }}"
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install system deps
+        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools xvfb
+
+      - name: Install repo deps
+        run: npm ci
+
+      - name: Install browser deps
+        run: npx playwright install --with-deps chromium
+
+      - name: Run upstream canary
+        id: canary
+        run: |
+          mkdir -p dist
+          set +e
+          xvfb-run -a node scripts/canary.mjs \
+            --json-output dist/upstream-canary.json \
+            > dist/upstream-canary.log 2>&1
+          status=$?
+          cat dist/upstream-canary.log
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          exit "${status}"
+
+      - name: Upload canary evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-canary-evidence
+          path: |
+            dist/upstream-canary.json
+            dist/upstream-canary.log
+
+      - name: Report scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/report-canary-failure.mjs \
+            --summary dist/upstream-canary.json \
+            --log dist/upstream-canary.log \
+            --repo "${{ github.repository }}" \
+            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --job-name "canary" \
+            --step-name "Run upstream canary"
+
+  publish-prod:
+    needs: [preflight, canary]
     if: github.event.inputs.force == 'true' || needs.preflight.outputs.prod_outdated == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -64,10 +126,13 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools
+        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools xvfb
 
       - name: Install repo deps
         run: npm ci
+
+      - name: Install browser deps
+        run: npx playwright install --with-deps chromium
 
       - name: Build channel
         run: |
@@ -98,6 +163,14 @@ jobs:
           echo "release_tag=$(jq -r '.releaseTag // ""' "$json")" >> "$GITHUB_OUTPUT"
           echo "package_version=$(jq -r '.packageVersion' "$json")" >> "$GITHUB_OUTPUT"
           echo "prerelease=$(jq -r '.prerelease // false' "$json")" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke channel
+        if: steps.meta.outputs.skipped != 'true'
+        run: |
+          xvfb-run -a node scripts/smoke-artifacts.mjs \
+            --channel "prod" \
+            --release-json "dist/prod-release.json" \
+            --json-output "dist/prod-smoke.json"
 
       - name: Generate release notes
         if: steps.meta.outputs.skipped != 'true'
@@ -218,7 +291,7 @@ jobs:
           git -C aur-prod push origin HEAD
 
   publish-beta:
-    needs: preflight
+    needs: [preflight, canary]
     if: github.event.inputs.force == 'true' || needs.preflight.outputs.beta_outdated == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -239,10 +312,13 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools
+        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools xvfb
 
       - name: Install repo deps
         run: npm ci
+
+      - name: Install browser deps
+        run: npx playwright install --with-deps chromium
 
       - name: Build channel
         run: |
@@ -273,6 +349,14 @@ jobs:
           echo "release_tag=$(jq -r '.releaseTag // ""' "$json")" >> "$GITHUB_OUTPUT"
           echo "package_version=$(jq -r '.packageVersion' "$json")" >> "$GITHUB_OUTPUT"
           echo "prerelease=$(jq -r '.prerelease // false' "$json")" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke channel
+        if: steps.meta.outputs.skipped != 'true'
+        run: |
+          xvfb-run -a node scripts/smoke-artifacts.mjs \
+            --channel "beta" \
+            --release-json "dist/beta-release.json" \
+            --json-output "dist/beta-smoke.json"
 
       - name: Generate release notes
         if: steps.meta.outputs.skipped != 'true'

--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -1,0 +1,84 @@
+name: upstream-canary
+
+on:
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: "17 3,15 * * *"
+
+jobs:
+  upstream-canary:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NPM_PACKAGE_NAME: "codex-app-linux"
+      CODEX_RELEASE_REPO: "${{ github.repository }}"
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install system deps
+        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools xvfb
+
+      - name: Install repo deps
+        run: npm ci
+
+      - name: Install browser deps
+        run: npx playwright install --with-deps chromium
+
+      - name: Run upstream canary
+        id: canary
+        run: |
+          mkdir -p dist
+          set +e
+          xvfb-run -a node scripts/canary.mjs \
+            --json-output dist/upstream-canary.json \
+            > dist/upstream-canary.log 2>&1
+          status=$?
+          cat dist/upstream-canary.log
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          exit "${status}"
+
+      - name: Upload canary evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upstream-canary-evidence
+          path: |
+            dist/upstream-canary.json
+            dist/upstream-canary.log
+
+  report-scheduled-failure:
+    needs: upstream-canary
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download canary evidence
+        uses: actions/download-artifact@v5
+        continue-on-error: true
+        with:
+          name: upstream-canary-evidence
+          path: dist
+
+      - name: Report scheduled failure
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/report-canary-failure.mjs \
+            --summary dist/upstream-canary.json \
+            --log dist/upstream-canary.log \
+            --repo "${{ github.repository }}" \
+            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --job-name "upstream-canary" \
+            --step-name "Run upstream canary"

--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -55,23 +55,30 @@ jobs:
 
   report-scheduled-failure:
     needs: upstream-canary
-    if: failure() && github.event_name == 'schedule'
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       issues: write
     steps:
+      - name: Skip report
+        if: github.event_name != 'schedule' || needs.upstream-canary.result != 'failure'
+        run: echo "No scheduled upstream canary failure to report"
+
       - uses: actions/checkout@v5
+        if: github.event_name == 'schedule' && needs.upstream-canary.result == 'failure'
 
       - name: Download canary evidence
-        uses: actions/download-artifact@v5
+        if: github.event_name == 'schedule' && needs.upstream-canary.result == 'failure'
+        uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           name: upstream-canary-evidence
           path: dist
 
       - name: Report scheduled failure
+        if: github.event_name == 'schedule' && needs.upstream-canary.result == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "acorn": "8.15.0",
         "electron": "42.1.0",
         "electron-builder": "26.8.1",
+        "playwright": "1.61.0",
         "ws": "8.20.0"
       }
     },
@@ -2854,6 +2855,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4065,6 +4081,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "author": "Zero Caulk <zero@composer.group>",
   "type": "module",
   "scripts": {
+    "canary": "node scripts/canary.mjs",
+    "smoke": "node scripts/smoke-artifacts.mjs",
     "test": "node --test",
     "release:prod": "node scripts/release-channel.mjs --channel prod",
     "release:beta": "node scripts/release-channel.mjs --channel beta"
@@ -16,6 +18,7 @@
     "acorn": "8.15.0",
     "electron": "42.1.0",
     "electron-builder": "26.8.1",
+    "playwright": "1.61.0",
     "ws": "8.20.0"
   }
 }

--- a/runtime/webstrap/server.mjs
+++ b/runtime/webstrap/server.mjs
@@ -493,7 +493,7 @@ if (isDirectRun) {
   });
 }
 
-function createAppHostModuleBody(rpcModulePath, webRoot) {
+export function createAppHostModuleBody(rpcModulePath, webRoot) {
   if (!rpcModulePath) {
     return "console.warn('codex-webstrap app host RPC module not found');\n";
   }
@@ -501,7 +501,19 @@ function createAppHostModuleBody(rpcModulePath, webRoot) {
   const rpcModuleUrl = `/${path.relative(webRoot, rpcModulePath).split(path.sep).join("/")}`;
 
   return `
-import { E as createRpcPeer } from ${JSON.stringify(rpcModuleUrl)};
+import * as rpcModule from ${JSON.stringify(rpcModuleUrl)};
+
+const createRpcPeer = [rpcModule.V, rpcModule.E, ...Object.values(rpcModule)].find((value) => {
+  if (typeof value !== "function") {
+    return false;
+  }
+
+  return Function.prototype.toString.call(value).includes("getRemoteMain");
+});
+
+if (typeof createRpcPeer !== "function") {
+  throw new Error("codex-webstrap app host RPC peer constructor not found");
+}
 
 const appUpdateSubscribers = new Set();
 const appUpdateState = {

--- a/scripts/canary.mjs
+++ b/scripts/canary.mjs
@@ -1,0 +1,186 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import { fetchAppcastMetadata } from "./lib/appcast.mjs";
+import { buildChannel } from "./lib/build.mjs";
+import {
+  defaultLauncherCommand,
+  defaultPackageName,
+  defaultReleaseRepo,
+  getChannel,
+  npmVersionFor,
+  parseArgs
+} from "./lib/config.mjs";
+import { smokeLinuxArtifacts } from "./smoke-artifacts.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const channelNames = parseChannels(args.channel);
+const packageName = String(args["package-name"] || defaultPackageName);
+const launcherCommand = String(args["app-command"] || defaultLauncherCommand);
+const releaseRepo = String(args["release-repo"] || defaultReleaseRepo);
+const jsonOutputPath = args["json-output"]
+  ? path.resolve(String(args["json-output"]))
+  : null;
+const runSmoke = args["no-smoke"] !== true;
+const runBrowser = args["no-browser"] !== true;
+const summary = {
+  ok: true,
+  packageName,
+  releaseRepo,
+  publishBlockedBeforeMutation: true,
+  startedAt: new Date().toISOString(),
+  channels: {},
+  failures: []
+};
+
+for (const channelName of channelNames) {
+  const channel = getChannel(channelName);
+  let upstream = null;
+  let packageVersion = null;
+  let phase = "fetch-appcast";
+
+  try {
+    upstream = await fetchAppcastMetadata(channel.appcastUrl);
+    packageVersion = npmVersionFor(channel.name, upstream);
+    phase = "build";
+
+    const build = await buildChannel({
+      channel,
+      upstream,
+      packageName,
+      launcherCommand,
+      releaseRepo
+    });
+
+    phase = "smoke";
+    const smoke = runSmoke
+      ? await smokeLinuxArtifacts({
+          channelName: channel.name,
+          linuxDir: build.linuxDir,
+          packageDir: build.packageDir,
+          browser: runBrowser
+        })
+      : null;
+
+    summary.channels[channel.name] = {
+      ok: true,
+      upstream,
+      packageVersion,
+      linuxDir: build.linuxDir,
+      packageDir: build.packageDir,
+      releaseTag: build.releaseTag,
+      smoke
+    };
+  } catch (error) {
+    const failure = normalizeCanaryFailure({
+      channel,
+      upstream,
+      packageVersion,
+      phase,
+      error
+    });
+
+    summary.ok = false;
+    summary.channels[channel.name] = {
+      ok: false,
+      upstream,
+      packageVersion,
+      failure
+    };
+    summary.failures.push(failure);
+  } finally {
+    if (jsonOutputPath) {
+      await writeJson(jsonOutputPath, summary);
+    }
+  }
+}
+
+summary.finishedAt = new Date().toISOString();
+
+if (jsonOutputPath) {
+  await writeJson(jsonOutputPath, summary);
+}
+
+process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+
+if (!summary.ok) {
+  process.exitCode = 1;
+}
+
+export function normalizeCanaryFailure({ channel, upstream, packageVersion, phase, error }) {
+  const message = toErrorMessage(error);
+  const failingName = failingContractOrSmokeName(error, message, phase);
+
+  return {
+    channel: channel.name,
+    phase,
+    failingName,
+    upstreamVersion: upstream?.version || "unknown",
+    upstreamBuildNumber: upstream?.buildNumber || "unknown",
+    packageVersion: packageVersion || "unknown",
+    fingerprint: `${channel.name}:${failingName}:${upstream?.version || "unknown"}:${upstream?.buildNumber || "unknown"}`,
+    errorMessage: message,
+    localReproductionCommand: `node scripts/canary.mjs --channel ${channel.name} --json-output dist/upstream-canary-${channel.name}.json`,
+    codePaths: codePathsForFailure(failingName, phase),
+    publishBlockedBeforeMutation: true
+  };
+}
+
+function parseChannels(value) {
+  if (!value) {
+    return ["prod", "beta"];
+  }
+
+  return String(value)
+    .split(",")
+    .map(channel => channel.trim())
+    .filter(Boolean);
+}
+
+function failingContractOrSmokeName(error, message, phase) {
+  if (error?.contractName) {
+    return error.contractName;
+  }
+
+  const smokeMatch = message.match(/^([a-z0-9_-]+) smoke failed:/i);
+  if (smokeMatch) {
+    return smokeMatch[1];
+  }
+
+  const contractMatch = message.match(/^([a-z0-9_-]+) contract changed:/i);
+  if (contractMatch) {
+    return contractMatch[1];
+  }
+
+  return phase;
+}
+
+function codePathsForFailure(name, phase) {
+  if (name.includes("open-target") || name.includes("window")) {
+    return ["scripts/lib/upstream-patches.mjs", "test/upstream-patches.test.mjs"];
+  }
+
+  if (name.includes("web")) {
+    return ["scripts/smoke-artifacts.mjs", "runtime/webstrap/server.mjs", "runtime/webstrap/message-router.mjs"];
+  }
+
+  if (name.includes("node_repl") || name.includes("native") || name.includes("desktop")) {
+    return ["scripts/smoke-artifacts.mjs", "scripts/lib/build.mjs", "runtime/launcher.mjs"];
+  }
+
+  if (phase === "build") {
+    return ["scripts/lib/build.mjs", "scripts/lib/upstream-patches.mjs"];
+  }
+
+  return ["scripts/canary.mjs"];
+}
+
+async function writeJson(filePath, body) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(body, null, 2)}\n`);
+}
+
+function toErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/scripts/lib/build.mjs
+++ b/scripts/lib/build.mjs
@@ -30,7 +30,7 @@ const skippedLinuxResourceNames = new Set([
   "node_repl",
   "rg"
 ]);
-const skippedBundledPluginNames = new Set(["computer-use", "latex-tectonic"]);
+const skippedBundledPluginNames = new Set(["computer-use", "latex", "latex-tectonic"]);
 const primaryRuntime = {
   url:
     process.env.CODEX_PRIMARY_RUNTIME_URL ||
@@ -561,6 +561,7 @@ export async function stagePackagedResources(resourcesDir, targetDir) {
 
     if (entry.name === "plugins") {
       await prunePackagedPlugins(targetPath);
+      await pruneForeignPackagedResources(targetPath);
     }
   }
 }
@@ -664,6 +665,80 @@ async function prunePackagedPlugins(pluginsDir) {
   await filterBundledPluginMarketplace(
     path.join(openaiBundledDir, ".agents", "plugins", "marketplace.json")
   );
+}
+
+async function pruneForeignPackagedResources(rootDir) {
+  const stack = [rootDir];
+
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (shouldPruneForeignDirectory(entry.name)) {
+          await fs.rm(fullPath, { recursive: true, force: true });
+          continue;
+        }
+
+        if (entry.name === "prebuilds") {
+          await pruneForeignPrebuilds(fullPath);
+          continue;
+        }
+
+        stack.push(fullPath);
+        continue;
+      }
+
+      if (entry.isFile() && shouldPruneForeignFile(entry.name)) {
+        await fs.rm(fullPath, { force: true });
+      }
+    }
+  }
+}
+
+async function pruneForeignPrebuilds(prebuildsDir) {
+  const entries = await fs.readdir(prebuildsDir, { withFileTypes: true }).catch(() => []);
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    if (entry.name === "linux-x64") {
+      continue;
+    }
+
+    await fs.rm(path.join(prebuildsDir, entry.name), {
+      recursive: true,
+      force: true
+    });
+  }
+}
+
+function shouldPruneForeignDirectory(name) {
+  return (
+    name.endsWith(".app") ||
+    name.endsWith(".framework") ||
+    name === "arm" ||
+    name === "arm64" ||
+    name === "aarch64" ||
+    name === "darwin" ||
+    name === "macos" ||
+    name === "win32" ||
+    name === "windows" ||
+    name.startsWith("darwin-") ||
+    name.startsWith("win32-") ||
+    name.startsWith("android-") ||
+    name === "linux-arm" ||
+    name === "linux-arm64"
+  );
+}
+
+function shouldPruneForeignFile(name) {
+  return name.endsWith(".dylib") || name.endsWith(".dll") || name.endsWith(".exe");
 }
 
 async function filterBundledPluginMarketplace(marketplacePath) {

--- a/scripts/lib/canary-issue.mjs
+++ b/scripts/lib/canary-issue.mjs
@@ -1,0 +1,90 @@
+export const canaryIssueLabels = ["upstream-canary", "release-blocker", "automated"];
+
+export function issueTitleForFailure(failure) {
+  return `Upstream canary failed: ${failure.channel} ${failure.failingName} ${failure.upstreamVersion}`;
+}
+
+export function issueBodyForFailure({
+  failure,
+  workflowUrl,
+  jobName,
+  stepName,
+  logExcerpt
+}) {
+  const codePaths = Array.isArray(failure.codePaths) && failure.codePaths.length > 0
+    ? failure.codePaths.map(file => `- \`${file}\``).join("\n")
+    : "- unknown";
+
+  return [
+    "Automated upstream canary failure.",
+    "",
+    `Fingerprint: \`${failure.fingerprint}\``,
+    "",
+    "| Field | Value |",
+    "| --- | --- |",
+    `| Workflow run | ${workflowUrl || "unknown"} |`,
+    `| Failing job | ${jobName || "unknown"} |`,
+    `| Failing step | ${stepName || failure.phase || "unknown"} |`,
+    `| Channel | ${failure.channel} |`,
+    `| Upstream version | ${failure.upstreamVersion} |`,
+    `| Upstream build | ${failure.upstreamBuildNumber} |`,
+    `| Package version | ${failure.packageVersion} |`,
+    `| Contract/smoke | ${failure.failingName} |`,
+    `| Publish blocked before mutation | ${failure.publishBlockedBeforeMutation ? "yes" : "unknown"} |`,
+    "",
+    "Exact error:",
+    "",
+    "```text",
+    failure.errorMessage || "unknown",
+    "```",
+    "",
+    "Relevant log excerpt:",
+    "",
+    "```text",
+    logExcerpt || "No log excerpt captured.",
+    "```",
+    "",
+    "Local reproduction:",
+    "",
+    "```bash",
+    failure.localReproductionCommand || `node scripts/canary.mjs --channel ${failure.channel}`,
+    "```",
+    "",
+    "Likely code paths:",
+    "",
+    codePaths
+  ].join("\n");
+}
+
+export function workflowFallbackFailure({
+  errorMessage,
+  localReproductionCommand = "node scripts/canary.mjs",
+  workflowUrl = ""
+} = {}) {
+  return {
+    channel: "unknown",
+    phase: "workflow",
+    failingName: "workflow-failure",
+    upstreamVersion: "unknown",
+    upstreamBuildNumber: "unknown",
+    packageVersion: "unknown",
+    fingerprint: "unknown:workflow-failure:unknown:unknown",
+    errorMessage: errorMessage || "Canary failed before writing a structured summary. Inspect the workflow log.",
+    localReproductionCommand: workflowUrl ? `gh run view ${workflowUrl} --log` : localReproductionCommand,
+    codePaths: [
+      ".github/workflows/upstream-canary.yml",
+      ".github/workflows/release.yml",
+      "scripts/canary.mjs",
+      "scripts/report-canary-failure.mjs"
+    ],
+    publishBlockedBeforeMutation: true
+  };
+}
+
+export function logExcerpt(logText, maxLines = 120) {
+  const lines = String(logText || "")
+    .split(/\r?\n/)
+    .filter(line => line.trim().length > 0);
+
+  return lines.slice(-maxLines).join("\n").slice(-12_000);
+}

--- a/scripts/lib/upstream-patches.mjs
+++ b/scripts/lib/upstream-patches.mjs
@@ -15,6 +15,56 @@ const linuxOpenTargetDefinitions = openCommandName => [
   "__codexLinuxZed={id:`zed`,platforms:{linux:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:()=>W(`zed`),args:__codexLinuxOpenTargetColonArgs}}}",
   "__codexLinuxNvim={id:`nvim`,platforms:{linux:{label:`Neovim`,icon:`apps/terminal.png`,kind:`editor`,detect:()=>W(`nvim`),args:__codexLinuxOpenTargetNvimArgs,open:__codexLinuxOpenTargetRunNvim}}}"
 ].join(",");
+const openTargetMapRegex =
+  /targets:\[\.\.\.([A-Za-z_$][\w$]*)\.map\(\(\{id:([A-Za-z_$][\w$]*),label:([A-Za-z_$][\w$]*),icon:([A-Za-z_$][\w$]*),kind:([A-Za-z_$][\w$]*),hidden:([A-Za-z_$][\w$]*)\}\)=>\(\{id:\2,target:\2,label:\3,icon:\4,kind:\5,hidden:\6,available:([A-Za-z_$][\w$]*)\.has\(\2\),default:([A-Za-z_$][\w$]*)===\2\|\|void 0\}\)\),\.\.\.([A-Za-z_$][\w$]*)\]/;
+const linuxTransparencyPatchedRegex =
+  /transparent:[A-Za-z_$][\w$]*===`linux`\?!1:[A-Za-z_$][\w$]*,hasShadow:/;
+const linuxTransparencyPatchRegex =
+  /function ([A-Za-z_$][\w$]*)\(\{alwaysOnTop:([A-Za-z_$][\w$]*),hasShadow:([A-Za-z_$][\w$]*)=!0,platform:([A-Za-z_$][\w$]*),resizable:([A-Za-z_$][\w$]*),thickFrame:([A-Za-z_$][\w$]*),transparent:([A-Za-z_$][\w$]*)=!0\}\)\{return\{frame:!1,transparent:\7,hasShadow:\3,/;
+
+export class UpstreamPatchContractError extends Error {
+  constructor(contractName, message, options = {}) {
+    super(`${contractName} contract changed: ${message}`, {
+      cause: options.cause
+    });
+    this.name = "UpstreamPatchContractError";
+    this.contractName = contractName;
+  }
+}
+
+export const upstreamPatchContracts = [
+  // Why: upstream desktop only registers macOS open-in-editor targets; Linux
+  // needs locally installed editors and terminal-backed Neovim. Contract:
+  // upstream still exposes an open-target registry, runner, and preferred-target
+  // mapper. Repro: node scripts/canary.mjs --channel prod --no-smoke.
+  {
+    name: "open-target-dispatcher",
+    find: findOpenTargetRegistry,
+    assertBefore: assertOpenTargetsBefore,
+    apply: applyLinuxOpenTargetsSource,
+    assertAfter: assertOpenTargetsAfter
+  },
+  // Why: transparent frameless windows render poorly under Linux compositors.
+  // Contract: the main bundle still builds BrowserWindow background options
+  // from the parsed window-options object. Repro: node scripts/canary.mjs --channel prod --no-smoke.
+  {
+    name: "linux-window-background",
+    find: findLinuxWindowBackgroundPatch,
+    assertBefore: assertLinuxWindowBackgroundBefore,
+    apply: patchLinuxWindowBackground,
+    assertAfter: assertLinuxWindowBackgroundAfter
+  },
+  // Why: Linux needs forced opaque windows even when upstream defaults are
+  // transparent. Contract: the minified BrowserWindow helper still returns the
+  // transparent option beside hasShadow. Repro: node scripts/canary.mjs --channel prod --no-smoke.
+  {
+    name: "linux-window-transparency",
+    find: findLinuxWindowTransparencyPatch,
+    assertBefore: assertLinuxWindowTransparencyBefore,
+    apply: patchLinuxWindowTransparency,
+    assertAfter: assertLinuxWindowTransparencyAfter
+  }
+];
 
 export async function patchUpstreamApp(stageAppDir) {
   const buildDir = path.join(stageAppDir, ".vite", "build");
@@ -37,15 +87,51 @@ export async function patchUpstreamApp(stageAppDir) {
 }
 
 export function patchUpstreamMainSource(source) {
-  let patched = source;
-
-  patched = patchLinuxOpenTargetsSource(patched);
-  patched = patchDisableTransparencySource(patched);
-
-  return patched;
+  return applyUpstreamPatchContracts(source, upstreamPatchContracts);
 }
 
 export function patchLinuxOpenTargetsSource(source) {
+  return applyUpstreamPatchContract(source, upstreamPatchContracts[0]);
+}
+
+export function patchDisableTransparencySource(source) {
+  return applyUpstreamPatchContracts(source, upstreamPatchContracts.slice(1));
+}
+
+export function applyUpstreamPatchContracts(source, contracts) {
+  return contracts.reduce(
+    (patched, contract) => applyUpstreamPatchContract(patched, contract),
+    source
+  );
+}
+
+export function applyUpstreamPatchContract(source, contract) {
+  try {
+    contract.find(source);
+
+    try {
+      contract.assertAfter(source);
+      return source;
+    } catch {
+      // Not already patched.
+    }
+
+    contract.assertBefore(source);
+    const patched = contract.apply(source);
+    contract.assertAfter(patched);
+    return patched;
+  } catch (error) {
+    if (error instanceof UpstreamPatchContractError) {
+      throw error;
+    }
+
+    throw new UpstreamPatchContractError(contract.name, error.message, {
+      cause: error
+    });
+  }
+}
+
+function applyLinuxOpenTargetsSource(source) {
   let patched = source;
 
   if (!patched.includes("__codexLinuxVSCode=")) {
@@ -64,13 +150,27 @@ export function patchLinuxOpenTargetsSource(source) {
   return patched;
 }
 
-export function patchDisableTransparencySource(source) {
-  let patched = source;
+function assertOpenTargetsBefore(source) {
+  findOpenTargetRegistry(source);
+  findOpenCommandName(source);
 
-  patched = patchLinuxWindowBackground(patched);
-  patched = patchLinuxWindowTransparency(patched);
+  if (!source.includes("appPath:process.platform===`linux`") && !openTargetMapRegex.test(source)) {
+    throw new Error("missing open target map");
+  }
+}
 
-  return patched;
+function assertOpenTargetsAfter(source) {
+  if (!source.includes("__codexLinuxVSCode=")) {
+    throw new Error("missing Linux open target definitions");
+  }
+
+  if (!source.includes("appPath:process.platform===`linux`")) {
+    throw new Error("missing Linux appPath target metadata");
+  }
+
+  if (source.includes("let n=t.platforms[e];return n")) {
+    throw new Error("open target platform lookup is not null-safe");
+  }
 }
 
 function patchLinuxWindowBackground(source) {
@@ -122,6 +222,22 @@ function findLinuxWindowBackgroundPatch(source) {
   }
 
   return null;
+}
+
+function assertLinuxWindowBackgroundBefore(source) {
+  const patch = findLinuxWindowBackgroundPatch(source);
+
+  if (!patch || patch.status !== "patch") {
+    throw new Error("missing window background helper");
+  }
+}
+
+function assertLinuxWindowBackgroundAfter(source) {
+  const patch = findLinuxWindowBackgroundPatch(source);
+
+  if (!patch || patch.status !== "patched") {
+    throw new Error("Linux window background assertion failed");
+  }
 }
 
 function linuxWindowBackgroundPatchForFunction(source, node) {
@@ -377,13 +493,11 @@ function isStringLiteral(node, value) {
 }
 
 function patchLinuxWindowTransparency(source) {
-  if (/transparent:[A-Za-z_$][\w$]*===`linux`\?!1:[A-Za-z_$][\w$]*,hasShadow:/.test(source)) {
+  if (linuxTransparencyPatchedRegex.test(source)) {
     return source;
   }
 
-  const match = source.match(
-    /function ([A-Za-z_$][\w$]*)\(\{alwaysOnTop:([A-Za-z_$][\w$]*),hasShadow:([A-Za-z_$][\w$]*)=!0,platform:([A-Za-z_$][\w$]*),resizable:([A-Za-z_$][\w$]*),thickFrame:([A-Za-z_$][\w$]*),transparent:([A-Za-z_$][\w$]*)=!0\}\)\{return\{frame:!1,transparent:\7,hasShadow:\3,/
-  );
+  const match = source.match(linuxTransparencyPatchRegex);
 
   if (!match) {
     throw new Error("Unable to apply upstream patch; missing window transparency helper");
@@ -398,14 +512,42 @@ function patchLinuxWindowTransparency(source) {
   return replaceOnce(source, anchor, replacement);
 }
 
+function findLinuxWindowTransparencyPatch(source) {
+  if (linuxTransparencyPatchedRegex.test(source)) {
+    return { status: "patched" };
+  }
+
+  const match = source.match(linuxTransparencyPatchRegex);
+
+  if (!match) {
+    return null;
+  }
+
+  return { status: "patch", match };
+}
+
+function assertLinuxWindowTransparencyBefore(source) {
+  const patch = findLinuxWindowTransparencyPatch(source);
+
+  if (!patch || patch.status !== "patch") {
+    throw new Error("missing window transparency helper");
+  }
+}
+
+function assertLinuxWindowTransparencyAfter(source) {
+  const patch = findLinuxWindowTransparencyPatch(source);
+
+  if (!patch || patch.status !== "patched") {
+    throw new Error("Linux window transparency assertion failed");
+  }
+}
+
 function patchOpenTargetMap(source) {
   if (source.includes("appPath:process.platform===`linux`")) {
     return source;
   }
 
-  const match = source.match(
-    /targets:\[\.\.\.([A-Za-z_$][\w$]*)\.map\(\(\{id:([A-Za-z_$][\w$]*),label:([A-Za-z_$][\w$]*),icon:([A-Za-z_$][\w$]*),kind:([A-Za-z_$][\w$]*),hidden:([A-Za-z_$][\w$]*)\}\)=>\(\{id:\2,target:\2,label:\3,icon:\4,kind:\5,hidden:\6,available:([A-Za-z_$][\w$]*)\.has\(\2\),default:([A-Za-z_$][\w$]*)===\2\|\|void 0\}\)\),\.\.\.([A-Za-z_$][\w$]*)\]/
-  );
+  const match = source.match(openTargetMapRegex);
 
   if (!match) {
     throw new Error("Unable to apply upstream patch; missing open target map");
@@ -442,7 +584,7 @@ function patchOpenTargetPlatformLookup(source) {
 
 function findOpenTargetRegistry(source) {
   const match = source.match(
-    /var ([A-Za-z_$][\w$]*)=\[[^\]]+\],[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\(`open-in-targets`\);function [A-Za-z_$][\w$]*\(e\)\{return \1\.flatMap/
+    /var ([A-Za-z_$][\w$]*)=\[[^\]]+\],[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\(`open-in-targets`\);\s*function [A-Za-z_$][\w$]*\(e\)\{return \1\.flatMap/
   );
 
   if (!match) {

--- a/scripts/release-channel.mjs
+++ b/scripts/release-channel.mjs
@@ -3,7 +3,7 @@ import process from "node:process";
 import fs from "node:fs/promises";
 
 import { fetchAppcastMetadata } from "./lib/appcast.mjs";
-import { buildChannel, npmVersionExists, publishPackage } from "./lib/build.mjs";
+import { buildChannel, npmVersionExists } from "./lib/build.mjs";
 import {
   defaultLauncherCommand,
   defaultPackageName,
@@ -30,6 +30,10 @@ const force = Boolean(args.force);
 const jsonOutputPath = args["json-output"]
   ? path.resolve(String(args["json-output"]))
   : null;
+
+if (publish) {
+  throw new Error("--publish is disabled; use the release workflow so canary and smoke gates run before publish");
+}
 
 const upstream = await fetchAppcastMetadata(channel.appcastUrl);
 const packageVersion = npmVersionFor(channel.name, upstream);
@@ -65,15 +69,12 @@ const result = await buildChannel({
   archiveOverride
 });
 
-if (publish) {
-  await publishPackage(result.packageDir, channel.distTag);
-}
-
 const summary = {
   channel: channel.name,
   packageName,
   packageVersion: result.npmVersion,
   archivePath: result.archivePath,
+  linuxDir: result.linuxDir,
   packageDir: result.packageDir,
   appImagePath: result.appImagePath,
   unpackedTarballPath: result.unpackedTarballPath,
@@ -84,7 +85,7 @@ const summary = {
   releaseRepo: result.releaseRepo,
   releaseTag: result.releaseTag,
   prerelease: channel.prerelease,
-  published: publish
+  published: false
 };
 
 if (jsonOutputPath) {

--- a/scripts/report-canary-failure.mjs
+++ b/scripts/report-canary-failure.mjs
@@ -1,0 +1,206 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawn } from "node:child_process";
+
+import { parseArgs } from "./lib/config.mjs";
+import {
+  canaryIssueLabels,
+  issueBodyForFailure,
+  issueTitleForFailure,
+  logExcerpt,
+  workflowFallbackFailure
+} from "./lib/canary-issue.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const summaryPath = args.summary ? path.resolve(String(args.summary)) : null;
+const logPath = args.log ? path.resolve(String(args.log)) : null;
+const repo = String(args.repo || process.env.GITHUB_REPOSITORY || "");
+const workflowUrl = String(args["workflow-url"] || defaultWorkflowUrl());
+const jobName = String(args["job-name"] || process.env.GITHUB_JOB || "");
+const stepName = String(args["step-name"] || "");
+
+if (!repo) {
+  throw new Error("--repo or GITHUB_REPOSITORY is required");
+}
+
+const logText = logPath ? await fs.readFile(logPath, "utf8").catch(() => "") : "";
+const summaryResult = await readSummary(summaryPath);
+const failures = summaryResult.ok && Array.isArray(summaryResult.summary.failures)
+  ? summaryResult.summary.failures
+  : [
+      workflowFallbackFailure({
+        workflowUrl,
+        errorMessage: summaryResult.errorMessage
+      })
+    ];
+
+if (failures.length === 0) {
+  process.stdout.write("No canary failures found; no issue written.\n");
+  process.exit(0);
+}
+
+async function readSummary(filePath) {
+  if (!filePath) {
+    return {
+      ok: false,
+      errorMessage: "--summary was not provided"
+    };
+  }
+
+  try {
+    return {
+      ok: true,
+      summary: JSON.parse(await fs.readFile(filePath, "utf8"))
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      errorMessage: `Canary failed before writing a structured summary: ${error.message}`
+    };
+  }
+}
+
+const availableLabels = await listAvailableLabels(repo);
+const labels = canaryIssueLabels.filter(label => availableLabels.has(label));
+const openIssues = await listOpenIssues(repo);
+
+for (const failure of failures) {
+  const title = issueTitleForFailure(failure);
+  const body = issueBodyForFailure({
+    failure,
+    workflowUrl,
+    jobName,
+    stepName,
+    logExcerpt: logExcerpt(logText)
+  });
+  const existing = openIssues.find(issue => issue.title === title);
+
+  if (existing) {
+    await updateIssue(repo, existing.number, body, labels);
+    process.stdout.write(`Updated issue #${existing.number}: ${title}\n`);
+  } else {
+    const issue = await createIssue(repo, title, body, labels);
+    process.stdout.write(`Created issue #${issue.number}: ${title}\n`);
+  }
+}
+
+async function listAvailableLabels(repo) {
+  const output = await gh(["label", "list", "--repo", repo, "--json", "name", "--limit", "200"], {
+    capture: true
+  }).catch(() => "[]");
+  const labels = JSON.parse(output);
+
+  return new Set(labels.map(label => label.name));
+}
+
+async function listOpenIssues(repo) {
+  const output = await gh([
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--json",
+    "number,title",
+    "--limit",
+    "200"
+  ], {
+    capture: true
+  });
+
+  return JSON.parse(output);
+}
+
+async function createIssue(repo, title, body, labels) {
+  const bodyFile = await writeTempBody(body);
+  const command = [
+    "issue",
+    "create",
+    "--repo",
+    repo,
+    "--title",
+    title,
+    "--body-file",
+    bodyFile
+  ];
+
+  if (labels.length > 0) {
+    command.push("--label", labels.join(","));
+  }
+
+  const output = await gh(command, { capture: true });
+  const number = Number(output.trim().match(/\/issues\/(\d+)$/)?.[1] || 0);
+
+  return {
+    number,
+    title
+  };
+}
+
+async function updateIssue(repo, number, body, labels) {
+  const bodyFile = await writeTempBody(body);
+  const command = [
+    "issue",
+    "edit",
+    String(number),
+    "--repo",
+    repo,
+    "--body-file",
+    bodyFile
+  ];
+
+  if (labels.length > 0) {
+    command.push("--add-label", labels.join(","));
+  }
+
+  await gh(command);
+}
+
+async function writeTempBody(body) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-canary-issue-"));
+  const filePath = path.join(dir, "body.md");
+
+  await fs.writeFile(filePath, body);
+  return filePath;
+}
+
+function gh(args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("gh", args, {
+      stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+      env: {
+        ...process.env,
+        GH_TOKEN: process.env.GH_TOKEN || process.env.GITHUB_TOKEN || ""
+      }
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout?.on("data", chunk => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", chunk => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("exit", code => {
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+
+      reject(new Error(`gh ${args.join(" ")} failed with ${code}\n${stderr}`));
+    });
+  });
+}
+
+function defaultWorkflowUrl() {
+  if (process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID) {
+    return `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+  }
+
+  return "";
+}

--- a/scripts/smoke-artifacts.mjs
+++ b/scripts/smoke-artifacts.mjs
@@ -1,0 +1,550 @@
+import fs from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import process from "node:process";
+import { spawn } from "node:child_process";
+
+import { channelPaths, getChannel, parseArgs, projectRoot } from "./lib/config.mjs";
+
+const nativeExtensions = new Set([
+  "",
+  ".AppImage",
+  ".bin",
+  ".dll",
+  ".dylib",
+  ".node",
+  ".so"
+]);
+
+if (isDirectRun()) {
+  const args = parseArgs(process.argv.slice(2));
+  const summary = await smokeLinuxArtifacts(await smokeOptionsFromArgs(args));
+
+  if (args["json-output"]) {
+    await writeJson(path.resolve(String(args["json-output"])), summary);
+  }
+
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}
+
+export async function smokeLinuxArtifacts({
+  channelName,
+  linuxDir,
+  packageDir,
+  webPort,
+  browser = true
+}) {
+  const channel = channelName ? getChannel(channelName) : null;
+  const executableName = channel?.executableName || await findDesktopExecutable(linuxDir);
+  const executablePath = path.join(linuxDir, executableName);
+  const resourcesDir = path.join(linuxDir, "resources");
+  const summary = {
+    channel: channelName || null,
+    linuxDir,
+    packageDir: packageDir || null,
+    checks: []
+  };
+
+  await accessFile(executablePath, "desktop executable");
+  await runCheck(summary, "linux-native-payloads", () =>
+    assertNoForeignNativePayloads(linuxDir)
+  );
+  await runCheck(summary, "node-runtime", () =>
+    assertCommandSuccess(path.join(resourcesDir, "node"), ["--version"], {
+      expectStdout: /^v\d+\.\d+\.\d+/
+    })
+  );
+  await runCheck(summary, "node_repl", () =>
+    smokeNodeRepl(path.join(resourcesDir, "node_repl"))
+  );
+  await runCheck(summary, "cua_node_repl", () =>
+    smokeNodeRepl(path.join(resourcesDir, "cua_node", "bin", "node_repl"))
+  );
+
+  if (packageDir) {
+    await runCheck(summary, "desktop-launcher-version", () =>
+      assertCommandSuccess(process.execPath, [path.join(packageDir, "runtime", "launcher.mjs"), "--version"], {
+        env: {
+          ...process.env,
+          CODEX_APP_LINUX_PACKAGE_ROOT: packageDir
+        },
+        expectStdout: /\d+\.\d+\.\d+/
+      })
+    );
+  }
+
+  await runCheck(summary, "desktop-binary-boot", () =>
+    smokeDesktopBinary(executablePath, resourcesDir)
+  );
+
+  if (browser) {
+    await runCheck(summary, "web-browser-shell", () =>
+      smokeWebShell({
+        linuxDir,
+        packageDir,
+        port: webPort || 0
+      })
+    );
+  }
+
+  return {
+    ...summary,
+    ok: summary.checks.every(check => check.ok)
+  };
+}
+
+async function smokeOptionsFromArgs(args) {
+  const channelName = args.channel ? String(args.channel) : null;
+  const releaseJsonPath = args["release-json"] ? path.resolve(String(args["release-json"])) : null;
+  const release = releaseJsonPath
+    ? JSON.parse(await fs.readFile(releaseJsonPath, "utf8"))
+    : {};
+  const paths = channelName ? channelPaths(channelName) : null;
+  const linuxDir = path.resolve(
+    String(args["linux-dir"] || release.linuxDir || (paths && path.join(paths.outputDir, "linux-unpacked")) || "")
+  );
+
+  if (!linuxDir || linuxDir === projectRoot) {
+    throw new Error("--linux-dir, --release-json, or --channel is required");
+  }
+
+  return {
+    channelName: channelName || release.channel || null,
+    linuxDir,
+    packageDir: args["package-dir"] || release.packageDir
+      ? path.resolve(String(args["package-dir"] || release.packageDir))
+      : null,
+    webPort: args["web-port"] ? Number(args["web-port"]) : 0,
+    browser: args["no-browser"] !== true
+  };
+}
+
+async function runCheck(summary, name, fn) {
+  const startedAt = Date.now();
+
+  try {
+    const detail = await fn();
+    summary.checks.push({
+      name,
+      ok: true,
+      durationMs: Date.now() - startedAt,
+      detail: detail || {}
+    });
+  } catch (error) {
+    summary.checks.push({
+      name,
+      ok: false,
+      durationMs: Date.now() - startedAt,
+      error: toErrorMessage(error)
+    });
+    throw new Error(`${name} smoke failed: ${toErrorMessage(error)}`, {
+      cause: error
+    });
+  }
+}
+
+async function assertNoForeignNativePayloads(rootDir) {
+  const files = await listFiles(rootDir);
+  const checked = [];
+
+  for (const filePath of files) {
+    const stat = await fs.stat(filePath);
+
+    if (!isNativeCandidate(filePath, stat)) {
+      continue;
+    }
+
+    const fileType = (await runCommand("file", ["-b", filePath], { capture: true })).stdout.trim();
+
+    if (isForeignNativeFileType(fileType)) {
+      throw new Error(`${path.relative(rootDir, filePath)} is not Linux x64: ${fileType}`);
+    }
+
+    checked.push(path.relative(rootDir, filePath));
+  }
+
+  return {
+    checked: checked.length
+  };
+}
+
+function isNativeCandidate(filePath, stat) {
+  const ext = path.extname(filePath);
+
+  return nativeExtensions.has(ext) || Boolean(stat.mode & 0o111);
+}
+
+function isForeignNativeFileType(fileType) {
+  if (/\bMach-O\b/i.test(fileType)) {
+    return true;
+  }
+
+  if (/\b(arm64|aarch64|ARM aarch64)\b/i.test(fileType)) {
+    return true;
+  }
+
+  if (/\bELF\b/i.test(fileType) && !/\bx86-64\b/i.test(fileType)) {
+    return true;
+  }
+
+  return /\bPE32\b/i.test(fileType);
+}
+
+async function smokeNodeRepl(executablePath) {
+  await accessFile(executablePath, "node_repl");
+
+  const result = await runCommand(executablePath, [], {
+    input: "",
+    capture: true,
+    timeoutMs: 5000
+  });
+  const combined = `${result.stdout}\n${result.stderr}`;
+
+  if (
+    result.code !== 1 ||
+    !combined.includes("failed to start stdio MCP server") ||
+    !combined.includes("initialize request")
+  ) {
+    throw new Error(`unexpected node_repl startup result: exit=${result.code} output=${combined.slice(0, 400)}`);
+  }
+
+  return {
+    exitCode: result.code
+  };
+}
+
+async function smokeDesktopBinary(executablePath, resourcesDir) {
+  const result = await runCommand(executablePath, ["--no-sandbox"], {
+    capture: true,
+    timeoutMs: 8000,
+    env: {
+      ...process.env,
+      CODEX_CLI_PATH: path.join(resourcesDir, "codex"),
+      ELECTRON_DISABLE_GPU: "1"
+    },
+    allowTimeout: true
+  });
+  const combined = `${result.stdout}\n${result.stderr}`;
+  const reachedBootLog = combined.includes("Launching app") || combined.includes("Codex CLI initialized");
+  const fatalOutput = /(Fatal|TypeError|ReferenceError|ErrorBoundary|segmentation fault|core dumped)/i.test(combined);
+
+  if (fatalOutput) {
+    throw new Error(`desktop binary printed fatal output: exit=${result.code} output=${combined.slice(0, 600)}`);
+  }
+
+  if (result.code && result.code !== 0 && !result.timedOut) {
+    throw new Error(`desktop binary exited early: exit=${result.code} output=${combined.slice(0, 600)}`);
+  }
+
+  if (!reachedBootLog && result.code !== 0) {
+    throw new Error(`desktop binary did not reach boot logs or exit cleanly: exit=${result.code} output=${combined.slice(0, 600)}`);
+  }
+
+  return {
+    exitCode: result.code,
+    timedOut: result.timedOut,
+    bootSignal: reachedBootLog ? "log" : "clean-exit"
+  };
+}
+
+async function smokeWebShell({ linuxDir, packageDir, port }) {
+  const actualPort = port || await allocatePort();
+  const serverPath = path.join(packageDir || projectRoot, "runtime", "webstrap", "server.mjs");
+  const server = spawn(process.execPath, [
+    serverPath,
+    "--codex-app",
+    linuxDir,
+    "--bind",
+    "127.0.0.1",
+    "--port",
+    String(actualPort),
+    "--dangerously-disable-auth",
+    "true"
+  ], {
+    cwd: projectRoot,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  const output = collectProcessOutput(server);
+
+  try {
+    await waitForHttpOk(`http://127.0.0.1:${actualPort}/__webstrapper/healthz`, 30_000);
+    await smokeBrowserPage(`http://127.0.0.1:${actualPort}/`);
+    return {
+      url: `http://127.0.0.1:${actualPort}/`
+    };
+  } finally {
+    await terminateProcess(server);
+
+    if (server.exitCode && server.exitCode !== 0) {
+      throw new Error(`web server exited with ${server.exitCode}: ${output().slice(0, 1000)}`);
+    }
+  }
+}
+
+async function smokeBrowserPage(url) {
+  let chromium;
+
+  try {
+    ({ chromium } = await import("playwright"));
+  } catch (error) {
+    throw new Error("Playwright is required for browser smoke. Run `npm install` and `npx playwright install chromium`.", {
+      cause: error
+    });
+  }
+
+  const browser = await chromium.launch({
+    headless: true
+  });
+  const page = await browser.newPage();
+  const fatalConsole = [];
+
+  page.on("console", message => {
+    const text = message.text();
+
+    if (
+      message.type() === "error" &&
+      /(Cannot read|TypeError|ReferenceError|ErrorBoundary|Update required|no longer supported|Fatal)/i.test(text)
+    ) {
+      fatalConsole.push(text);
+    }
+  });
+  page.on("pageerror", error => {
+    fatalConsole.push(toErrorMessage(error));
+  });
+
+  try {
+    await page.goto(url, {
+      waitUntil: "domcontentloaded",
+      timeout: 30_000
+    });
+    await page.waitForFunction(() => {
+      const body = document.body;
+      const text = body?.innerText || "";
+
+      if (/Update required|no longer supported/i.test(text)) {
+        return false;
+      }
+
+      const interactive = document.querySelector(
+        'textarea,input,[contenteditable="true"],button,[role="button"],[role="textbox"],[aria-label*="New"],[aria-label*="chat" i]'
+      );
+      const splashOnly = body?.children.length <= 2 && document.querySelector("svg") && text.trim().length < 20;
+
+      return Boolean(interactive) || (text.trim().length > 20 && !splashOnly);
+    }, {
+      timeout: 45_000
+    });
+
+    if (fatalConsole.length > 0) {
+      throw new Error(`fatal browser console output: ${fatalConsole.slice(0, 5).join("\n")}`);
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+async function assertCommandSuccess(command, args, options = {}) {
+  const result = await runCommand(command, args, {
+    capture: true,
+    timeoutMs: options.timeoutMs || 5000,
+    env: options.env
+  });
+
+  if (result.code !== 0) {
+    throw new Error(`${command} exited ${result.code}: ${result.stderr || result.stdout}`);
+  }
+
+  if (options.expectStdout && !options.expectStdout.test(result.stdout.trim())) {
+    throw new Error(`${command} stdout did not match ${options.expectStdout}: ${result.stdout.trim()}`);
+  }
+
+  return {
+    stdout: result.stdout.trim()
+  };
+}
+
+async function listFiles(rootDir) {
+  const files = [];
+  const stack = [rootDir];
+
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      } else if (entry.isFile()) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+async function findDesktopExecutable(linuxDir) {
+  const entries = await fs.readdir(linuxDir, { withFileTypes: true });
+  const executable = entries.find(entry => entry.isFile() && entry.name.startsWith("codex-app-linux"));
+
+  if (!executable) {
+    throw new Error(`Unable to find desktop executable under ${linuxDir}`);
+  }
+
+  return executable.name;
+}
+
+async function waitForHttpOk(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // server still starting
+    }
+
+    await sleep(250);
+  }
+
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function allocatePort() {
+  const server = net.createServer();
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+
+  await new Promise(resolve => server.close(resolve));
+
+  if (!port) {
+    throw new Error("Failed to allocate web smoke port");
+  }
+
+  return port;
+}
+
+function runCommand(command, args, options = {}) {
+  const {
+    allowTimeout = false,
+    capture = false,
+    env = process.env,
+    input,
+    timeoutMs = 30_000
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: projectRoot,
+      env,
+      stdio: capture ? ["pipe", "pipe", "pipe"] : "inherit"
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, timeoutMs);
+
+    child.stdout?.on("data", chunk => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", chunk => {
+      stderr += chunk.toString();
+    });
+    child.on("error", error => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("exit", code => {
+      clearTimeout(timer);
+
+      if (timedOut && !allowTimeout) {
+        reject(new Error(`${command} timed out after ${timeoutMs}ms`));
+        return;
+      }
+
+      resolve({
+        code,
+        timedOut,
+        stdout,
+        stderr
+      });
+    });
+
+    if (input !== undefined) {
+      child.stdin?.end(input);
+    }
+  });
+}
+
+function collectProcessOutput(child) {
+  let stdout = "";
+  let stderr = "";
+
+  child.stdout?.on("data", chunk => {
+    stdout += chunk.toString();
+  });
+  child.stderr?.on("data", chunk => {
+    stderr += chunk.toString();
+  });
+
+  return () => `${stdout}\n${stderr}`;
+}
+
+async function terminateProcess(child) {
+  if (child.exitCode != null || child.signalCode != null) {
+    return;
+  }
+
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise(resolve => child.once("exit", resolve)),
+    sleep(3000).then(() => {
+      if (child.exitCode == null && child.signalCode == null) {
+        child.kill("SIGKILL");
+      }
+    })
+  ]);
+}
+
+async function accessFile(filePath, label) {
+  try {
+    await fs.access(filePath);
+  } catch (error) {
+    throw new Error(`Missing ${label}: ${filePath}`, {
+      cause: error
+    });
+  }
+}
+
+async function writeJson(filePath, body) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(body, null, 2)}\n`);
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function toErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isDirectRun() {
+  return process.argv[1] && path.resolve(process.argv[1]) === new URL(import.meta.url).pathname;
+}

--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -18,8 +18,15 @@ test("stagePackagedResources preserves Linux-safe upstream resources", async () 
 
   await fs.mkdir(path.join(resourcesDir, "plugins", "openai-bundled", ".agents", "plugins"), { recursive: true });
   await fs.mkdir(path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "browser-use"), { recursive: true });
+  await fs.mkdir(path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "browser", "scripts", "node_modules", "classic-level", "prebuilds", "darwin-x64+arm64"), { recursive: true });
+  await fs.mkdir(path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "browser", "scripts", "node_modules", "classic-level", "prebuilds", "linux-arm64"), { recursive: true });
+  await fs.mkdir(path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "browser", "scripts", "node_modules", "classic-level", "prebuilds", "linux-x64"), { recursive: true });
+  await fs.mkdir(path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "chrome", "extension-host", "macos", "arm64"), { recursive: true });
+  await fs.mkdir(path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "chrome", "extension-host", "linux", "x64"), { recursive: true });
   await fs.mkdir(path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "computer-use"), { recursive: true });
+  await fs.mkdir(path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "latex", "bin"), { recursive: true });
   await fs.mkdir(path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "latex-tectonic", "bin"), { recursive: true });
+  await fs.mkdir(path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "record-and-replay", "Codex Computer Use.app", "Contents", "MacOS"), { recursive: true });
   await fs.mkdir(path.join(resourcesDir, "native"), { recursive: true });
   await fs.mkdir(path.join(resourcesDir, "app.asar.unpacked", "node_modules"), { recursive: true });
   await fs.writeFile(path.join(resourcesDir, "app.asar"), "asar");
@@ -35,6 +42,7 @@ test("stagePackagedResources preserves Linux-safe upstream resources", async () 
         plugins: [
           { name: "browser-use", source: { source: "local", path: "./plugins/browser-use" } },
           { name: "computer-use", source: { source: "local", path: "./plugins/computer-use" } },
+          { name: "latex", source: { source: "local", path: "./plugins/latex" } },
           { name: "latex-tectonic", source: { source: "local", path: "./plugins/latex-tectonic" } }
         ]
       },
@@ -47,12 +55,40 @@ test("stagePackagedResources preserves Linux-safe upstream resources", async () 
     "browser-use"
   );
   await fs.writeFile(
+    path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "browser", "scripts", "node_modules", "classic-level", "prebuilds", "darwin-x64+arm64", "classic-level.node"),
+    "darwin-fat-native"
+  );
+  await fs.writeFile(
+    path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "browser", "scripts", "node_modules", "classic-level", "prebuilds", "linux-arm64", "classic-level.node"),
+    "linux-arm64-native"
+  );
+  await fs.writeFile(
+    path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "browser", "scripts", "node_modules", "classic-level", "prebuilds", "linux-x64", "classic-level.node"),
+    "linux-x64-native"
+  );
+  await fs.writeFile(
+    path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "chrome", "extension-host", "macos", "arm64", "extension-host"),
+    "darwin-extension-host"
+  );
+  await fs.writeFile(
+    path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "chrome", "extension-host", "linux", "x64", "extension-host"),
+    "linux-extension-host"
+  );
+  await fs.writeFile(
     path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "computer-use", "plugin.json"),
     "computer-use"
   );
   await fs.writeFile(
+    path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "latex", "bin", "tectonic"),
+    "darwin-tectonic"
+  );
+  await fs.writeFile(
     path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "latex-tectonic", "bin", "tectonic"),
     "darwin-tectonic"
+  );
+  await fs.writeFile(
+    path.join(resourcesDir, "plugins", "openai-bundled", "plugins", "record-and-replay", "Codex Computer Use.app", "Contents", "MacOS", "SkyComputerUseService"),
+    "mach-o-arm64"
   );
   await fs.writeFile(path.join(resourcesDir, "codex"), "darwin-codex");
   await fs.mkdir(path.join(resourcesDir, "cua_node", "bin"), { recursive: true });
@@ -73,13 +109,32 @@ test("stagePackagedResources preserves Linux-safe upstream resources", async () 
   await assert.rejects(fs.access(path.join(targetDir, "rg")));
   await assert.rejects(fs.access(path.join(targetDir, "native")));
   await assert.rejects(fs.access(path.join(targetDir, "plugins", "openai-bundled", "plugins", "computer-use")));
+  await assert.rejects(fs.access(path.join(targetDir, "plugins", "openai-bundled", "plugins", "latex")));
   await assert.rejects(fs.access(path.join(targetDir, "plugins", "openai-bundled", "plugins", "latex-tectonic")));
+  await assert.rejects(fs.access(path.join(targetDir, "plugins", "openai-bundled", "plugins", "record-and-replay", "Codex Computer Use.app")));
+  await assert.rejects(fs.access(path.join(targetDir, "plugins", "openai-bundled", "plugins", "browser", "scripts", "node_modules", "classic-level", "prebuilds", "darwin-x64+arm64")));
+  await assert.rejects(fs.access(path.join(targetDir, "plugins", "openai-bundled", "plugins", "browser", "scripts", "node_modules", "classic-level", "prebuilds", "linux-arm64")));
+  await assert.rejects(fs.access(path.join(targetDir, "plugins", "openai-bundled", "plugins", "chrome", "extension-host", "macos")));
   assert.equal(
     await fs.readFile(
       path.join(targetDir, "plugins", "openai-bundled", "plugins", "browser-use", "plugin.json"),
       "utf8"
     ),
     "browser-use"
+  );
+  assert.equal(
+    await fs.readFile(
+      path.join(targetDir, "plugins", "openai-bundled", "plugins", "browser", "scripts", "node_modules", "classic-level", "prebuilds", "linux-x64", "classic-level.node"),
+      "utf8"
+    ),
+    "linux-x64-native"
+  );
+  assert.equal(
+    await fs.readFile(
+      path.join(targetDir, "plugins", "openai-bundled", "plugins", "chrome", "extension-host", "linux", "x64", "extension-host"),
+      "utf8"
+    ),
+    "linux-extension-host"
   );
   const marketplace = JSON.parse(
     await fs.readFile(

--- a/test/canary-issue.test.mjs
+++ b/test/canary-issue.test.mjs
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  issueBodyForFailure,
+  issueTitleForFailure,
+  logExcerpt,
+  workflowFallbackFailure
+} from "../scripts/lib/canary-issue.mjs";
+
+const failure = {
+  channel: "prod",
+  phase: "build",
+  failingName: "open-target-dispatcher",
+  upstreamVersion: "26.616.30709",
+  upstreamBuildNumber: "30709",
+  packageVersion: "26.616.30709-launcher.29",
+  fingerprint: "prod:open-target-dispatcher:26.616.30709:30709",
+  errorMessage: "open-target-dispatcher contract changed: missing runner",
+  localReproductionCommand: "node scripts/canary.mjs --channel prod --json-output dist/upstream-canary-prod.json",
+  codePaths: ["scripts/lib/upstream-patches.mjs"],
+  publishBlockedBeforeMutation: true
+};
+
+test("canary issue title uses stable dedupe fields", () => {
+  assert.equal(
+    issueTitleForFailure(failure),
+    "Upstream canary failed: prod open-target-dispatcher 26.616.30709"
+  );
+});
+
+test("canary issue body includes actionable repair evidence", () => {
+  const body = issueBodyForFailure({
+    failure,
+    workflowUrl: "https://github.com/better-slop/codex-app-linux/actions/runs/1",
+    jobName: "upstream-canary",
+    stepName: "Run upstream canary",
+    logExcerpt: "stack line"
+  });
+
+  assert.match(body, /Workflow run/);
+  assert.match(body, /Channel \| prod/);
+  assert.match(body, /Upstream build \| 30709/);
+  assert.match(body, /Package version \| 26\.616\.30709-launcher\.29/);
+  assert.match(body, /Contract\/smoke \| open-target-dispatcher/);
+  assert.match(body, /Publish blocked before mutation \| yes/);
+  assert.match(body, /missing runner/);
+  assert.match(body, /stack line/);
+  assert.match(body, /node scripts\/canary\.mjs --channel prod/);
+  assert.match(body, /scripts\/lib\/upstream-patches\.mjs/);
+});
+
+test("logExcerpt keeps the tail of long logs", () => {
+  const text = Array.from({ length: 130 }, (_, index) => `line-${index}`).join("\n");
+  const excerpt = logExcerpt(text, 5);
+
+  assert.equal(excerpt, ["line-125", "line-126", "line-127", "line-128", "line-129"].join("\n"));
+});
+
+test("workflowFallbackFailure files an issue when canary summary is missing", () => {
+  const fallback = workflowFallbackFailure({
+    workflowUrl: "https://github.com/better-slop/codex-app-linux/actions/runs/1",
+    errorMessage: "ENOENT dist/upstream-canary.json"
+  });
+
+  assert.equal(issueTitleForFailure(fallback), "Upstream canary failed: unknown workflow-failure unknown");
+  assert.equal(fallback.publishBlockedBeforeMutation, true);
+  assert.match(fallback.localReproductionCommand, /gh run view/);
+  assert.match(fallback.errorMessage, /ENOENT/);
+  assert.deepEqual(
+    fallback.codePaths,
+    [
+      ".github/workflows/upstream-canary.yml",
+      ".github/workflows/release.yml",
+      "scripts/canary.mjs",
+      "scripts/report-canary-failure.mjs"
+    ]
+  );
+});

--- a/test/canary-reporter.test.mjs
+++ b/test/canary-reporter.test.mjs
@@ -1,0 +1,161 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+test("report-canary-failure creates exactly one actionable GitHub issue", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-canary-reporter-"));
+  const callsPath = path.join(root, "gh-calls.jsonl");
+  const fakeGhPath = await writeFakeGh(root, callsPath);
+  const summaryPath = path.join(root, "summary.json");
+  const logPath = path.join(root, "canary.log");
+
+  await fs.writeFile(
+    summaryPath,
+    `${JSON.stringify({
+      failures: [
+        {
+          channel: "prod",
+          phase: "build",
+          failingName: "open-target-dispatcher",
+          upstreamVersion: "26.616.30709",
+          upstreamBuildNumber: "4108",
+          packageVersion: "26.616.30709-launcher.29",
+          fingerprint: "prod:open-target-dispatcher:26.616.30709:4108",
+          errorMessage: "open-target-dispatcher contract changed: missing runner",
+          localReproductionCommand: "node scripts/canary.mjs --channel prod",
+          codePaths: ["scripts/lib/upstream-patches.mjs"],
+          publishBlockedBeforeMutation: true
+        }
+      ]
+    })}\n`
+  );
+  await fs.writeFile(logPath, "canary log excerpt\n");
+
+  await execFileAsync(process.execPath, [
+    "scripts/report-canary-failure.mjs",
+    "--summary",
+    summaryPath,
+    "--log",
+    logPath,
+    "--repo",
+    "better-slop/codex-app-linux",
+    "--workflow-url",
+    "https://github.com/better-slop/codex-app-linux/actions/runs/1",
+    "--job-name",
+    "upstream-canary",
+    "--step-name",
+    "Run upstream canary"
+  ], {
+    env: {
+      ...process.env,
+      PATH: `${path.dirname(fakeGhPath)}:${process.env.PATH}`,
+      FAKE_GH_CALLS: callsPath
+    }
+  });
+
+  const calls = await readFakeGhCalls(callsPath);
+  const issueMutations = calls.filter(args => args[0] === "issue" && ["create", "edit"].includes(args[1]));
+
+  assert.equal(issueMutations.length, 1);
+  assert.equal(issueMutations[0][1], "create");
+  assert.match(issueMutations[0].join(" "), /Upstream canary failed: prod open-target-dispatcher 26\.616\.30709/);
+
+  const body = await readBodyFileFromArgs(issueMutations[0]);
+  assert.match(body, /Workflow run \| https:\/\/github\.com\/better-slop\/codex-app-linux\/actions\/runs\/1/);
+  assert.match(body, /Failing job \| upstream-canary/);
+  assert.match(body, /Failing step \| Run upstream canary/);
+  assert.match(body, /Channel \| prod/);
+  assert.match(body, /Upstream build \| 4108/);
+  assert.match(body, /Package version \| 26\.616\.30709-launcher\.29/);
+  assert.match(body, /open-target-dispatcher contract changed/);
+  assert.match(body, /canary log excerpt/);
+  assert.match(body, /scripts\/lib\/upstream-patches\.mjs/);
+  assert.match(body, /Publish blocked before mutation \| yes/);
+});
+
+test("report-canary-failure updates exactly one existing GitHub issue", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-canary-reporter-update-"));
+  const callsPath = path.join(root, "gh-calls.jsonl");
+  const fakeGhPath = await writeFakeGh(root, callsPath);
+  const summaryPath = path.join(root, "summary.json");
+  const title = "Upstream canary failed: unknown workflow-failure unknown";
+
+  await fs.writeFile(summaryPath, "{}\n");
+
+  await execFileAsync(process.execPath, [
+    "scripts/report-canary-failure.mjs",
+    "--summary",
+    summaryPath,
+    "--repo",
+    "better-slop/codex-app-linux"
+  ], {
+    env: {
+      ...process.env,
+      PATH: `${path.dirname(fakeGhPath)}:${process.env.PATH}`,
+      FAKE_GH_CALLS: callsPath,
+      FAKE_GH_ISSUES: JSON.stringify([{ number: 77, title }])
+    }
+  });
+
+  const calls = await readFakeGhCalls(callsPath);
+  const issueMutations = calls.filter(args => args[0] === "issue" && ["create", "edit"].includes(args[1]));
+
+  assert.equal(issueMutations.length, 1);
+  assert.deepEqual(issueMutations[0].slice(0, 3), ["issue", "edit", "77"]);
+});
+
+async function writeFakeGh(root, callsPath) {
+  const fakeGhPath = path.join(root, "gh");
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_GH_CALLS, JSON.stringify(args) + "\\n");
+if (args[0] === "label" && args[1] === "list") {
+  console.log(JSON.stringify([
+    { name: "upstream-canary" },
+    { name: "release-blocker" },
+    { name: "automated" }
+  ]));
+  process.exit(0);
+}
+if (args[0] === "issue" && args[1] === "list") {
+  console.log(process.env.FAKE_GH_ISSUES || "[]");
+  process.exit(0);
+}
+if (args[0] === "issue" && args[1] === "create") {
+  console.log("https://github.com/better-slop/codex-app-linux/issues/123");
+  process.exit(0);
+}
+if (args[0] === "issue" && args[1] === "edit") {
+  process.exit(0);
+}
+process.exit(0);
+`;
+
+  await fs.writeFile(fakeGhPath, script, { mode: 0o755 });
+  await fs.writeFile(callsPath, "");
+  return fakeGhPath;
+}
+
+async function readFakeGhCalls(callsPath) {
+  const text = await fs.readFile(callsPath, "utf8");
+
+  return text
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map(line => JSON.parse(line));
+}
+
+async function readBodyFileFromArgs(args) {
+  const bodyFileIndex = args.indexOf("--body-file");
+
+  assert.notEqual(bodyFileIndex, -1);
+  return fs.readFile(args[bodyFileIndex + 1], "utf8");
+}

--- a/test/fixtures/upstream-main-26.616.30709-open-target.slice.txt
+++ b/test/fixtures/upstream-main-26.616.30709-open-target.slice.txt
@@ -1,0 +1,7 @@
+function DN(e){let t=e.indexOf(`.app/Contents/MacOS/`);return t===-1?null:e.slice(0,t+4)}
+async function ON({command:e,path:t,location:n,hostConfig:r,remoteWorkspaceRoot:i,remotePath:a}){let o=qM(t,n,r,i,a),s=o[0]??t,c=n==null?s:qM(t,null,r,i,a)[0]??s,l=DN(e);if(l){if(await no(`open`,[`-a`,l,c]),!n)return;let t=Qa(`zed`)??e;try{await no(t,o)}catch{}return}await no(e,o)}
+var kN=[cN,uN,oN,lM,Bj,pM,XM,wN,pN,Rj,SM,$M,mM,Hj,yM,sM,hN,wM,vM,fN,yN,AM,jM,MM,NM,PM,FM,IM,LM,nN],AN=t.qr(`open-in-targets`);
+function jN(e){return kN.flatMap(t=>{let n=t.platforms[e];return n?[{id:t.id,...n}]:[]})}
+var MN=jN(process.platform),NN=HN(MN),PN=new WeakMap,FN=new WeakMap,IN=async e=>a.shell.readShortcutLink(e);
+async function BN(e,t,{appPath:n,detectedCommand:r,hostConfig:i,location:a,remotePath:o,remoteWorkspaceRoot:s,targets:c=MN}={}){if(o!=null&&i?.kind===`remote-control`)throw Error(`Remote control does not support open in ${e} yet.`);let l=c.find(t=>t.id===e);if(!l)throw Error(`Unknown open target "${e}"`);let u=r??await l.detect(IN);if(!u)throw Error(`Open target "${e}" is not available`);if(l.open){await l.open({command:u,path:t,appPath:n,location:a,hostConfig:i,remoteWorkspaceRoot:s,remotePath:o});return}await no(u,l.args(t,a,i,s,o),{env:l.env?.()})}
+function preferredTargets(){return{targets:[...l.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:m.has(e),default:h===e||void 0})),...y]}}

--- a/test/release-workflow.test.mjs
+++ b/test/release-workflow.test.mjs
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 test("release workflow refuses existing npm versions before clobbering release assets", async () => {
   const workflow = await fs.readFile(".github/workflows/release.yml", "utf8");
@@ -15,4 +19,50 @@ test("release workflow refuses existing npm versions before clobbering release a
   assert.match(workflow, /npm package version already exists; refusing to clobber/);
   assert.ok(prodGuard < prodUpload);
   assert.ok(betaGuard < betaUpload);
+});
+
+test("release workflow runs canary and smoke before publish mutations", async () => {
+  const workflow = await fs.readFile(".github/workflows/release.yml", "utf8");
+  const canaryJob = workflow.indexOf("  canary:");
+  const publishProd = workflow.indexOf("  publish-prod:");
+  const publishBeta = workflow.indexOf("  publish-beta:");
+  const prodSmoke = workflow.indexOf("Smoke channel", publishProd);
+  const betaSmoke = workflow.indexOf("Smoke channel", publishBeta);
+  const prodRelease = workflow.indexOf("Create or update GitHub release", publishProd);
+  const betaRelease = workflow.indexOf("Create or update GitHub release", publishBeta);
+
+  assert.ok(canaryJob > 0);
+  assert.ok(canaryJob < publishProd);
+  assert.ok(canaryJob < publishBeta);
+  assert.match(workflow, /publish-prod:\n\s+needs: \[preflight, canary\]/);
+  assert.match(workflow, /publish-beta:\n\s+needs: \[preflight, canary\]/);
+  assert.ok(prodSmoke < prodRelease);
+  assert.ok(betaSmoke < betaRelease);
+});
+
+test("upstream canary workflow reports scheduled failures without publish permissions", async () => {
+  const workflow = await fs.readFile(".github/workflows/upstream-canary.yml", "utf8");
+  const canaryJob = workflow.slice(
+    workflow.indexOf("  upstream-canary:"),
+    workflow.indexOf("  report-scheduled-failure:")
+  );
+
+  assert.match(workflow, /pull_request:/);
+  assert.match(workflow, /schedule:/);
+  assert.match(workflow, /contents: read/);
+  assert.doesNotMatch(canaryJob, /issues: write/);
+  assert.doesNotMatch(workflow, /id-token: write/);
+  assert.doesNotMatch(workflow, /npm publish|gh release upload|aur\.archlinux/);
+  assert.match(workflow, /node scripts\/report-canary-failure\.mjs/);
+  assert.match(workflow, /github\.event_name == 'schedule'/);
+});
+
+test("release-channel CLI refuses direct publish bypass", async () => {
+  await assert.rejects(
+    execFileAsync(process.execPath, ["scripts/release-channel.mjs", "--channel", "prod", "--publish"]),
+    error => {
+      assert.match(error.stderr, /--publish is disabled/);
+      return true;
+    }
+  );
 });

--- a/test/release-workflow.test.mjs
+++ b/test/release-workflow.test.mjs
@@ -55,6 +55,8 @@ test("upstream canary workflow reports scheduled failures without publish permis
   assert.doesNotMatch(workflow, /npm publish|gh release upload|aur\.archlinux/);
   assert.match(workflow, /node scripts\/report-canary-failure\.mjs/);
   assert.match(workflow, /github\.event_name == 'schedule'/);
+  assert.match(workflow, /No scheduled upstream canary failure to report/);
+  assert.match(workflow, /needs\.upstream-canary\.result == 'failure'/);
 });
 
 test("release-channel CLI refuses direct publish bypass", async () => {

--- a/test/upstream-patches.test.mjs
+++ b/test/upstream-patches.test.mjs
@@ -1,9 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
 
 import {
   patchDisableTransparencySource,
-  patchLinuxOpenTargetsSource
+  patchLinuxOpenTargetsSource,
+  upstreamPatchContracts
 } from "../scripts/lib/upstream-patches.mjs";
 
 test("patchLinuxOpenTargetsSource adds Linux editor targets and exposes app paths", () => {
@@ -101,6 +103,46 @@ test("patchLinuxOpenTargetsSource accepts upstream dispatcher runner shape", () 
   assert.match(
     patched,
     /await no\(r\.command,r\.args\(__codexLinuxOpenTargetNvimCommand\(e,t,n\)\)\)/
+  );
+});
+
+test("patchLinuxOpenTargetsSource accepts latest real upstream dispatcher fixture slice", async () => {
+  const source = await fs.readFile(
+    "test/fixtures/upstream-main-26.616.30709-open-target.slice.txt",
+    "utf8"
+  );
+
+  const patched = patchLinuxOpenTargetsSource(source);
+
+  assert.match(
+    patched,
+    /var kN=\[__codexLinuxVSCode,__codexLinuxVSCodeInsiders,__codexLinuxCursor,__codexLinuxZed,__codexLinuxNvim,cN,uN/
+  );
+  assert.match(
+    patched,
+    /await no\(r\.command,r\.args\(__codexLinuxOpenTargetNvimCommand\(e,t,n\)\)\)/
+  );
+  assert.match(
+    patched,
+    /appPath:process\.platform===`linux`&&r===`editor`&&m\.has\(e\)\?Ld\(\)\.get\(e\)\?\?null:null/
+  );
+});
+
+test("upstream patch contracts declare required contract surface", () => {
+  assert.deepEqual(
+    upstreamPatchContracts.map(contract => Object.keys(contract).sort()),
+    upstreamPatchContracts.map(() => ["apply", "assertAfter", "assertBefore", "find", "name"])
+  );
+  assert.deepEqual(
+    upstreamPatchContracts.map(contract => contract.name),
+    ["open-target-dispatcher", "linux-window-background", "linux-window-transparency"]
+  );
+});
+
+test("patchLinuxOpenTargetsSource reports contract name on upstream drift", () => {
+  assert.throws(
+    () => patchLinuxOpenTargetsSource("function nope(){}"),
+    /open-target-dispatcher contract changed: Unable to apply upstream patch; missing open target registry/
   );
 });
 

--- a/test/web-assets.test.mjs
+++ b/test/web-assets.test.mjs
@@ -13,6 +13,7 @@ import {
   readExtractedBuildMetadata,
   resolveCodexAppPaths
 } from "../runtime/webstrap/assets.mjs";
+import { createAppHostModuleBody } from "../runtime/webstrap/server.mjs";
 import { safePathJoin } from "../runtime/webstrap/util.mjs";
 
 test("resolveCodexAppPaths supports linux-unpacked layout", async () => {
@@ -105,6 +106,18 @@ test("buildPatchedIndexHtml installs web app host before upstream app entry", as
 
   assert.match(patched, /<script type="module" src="\/__webstrapper\/app-host\.js"><\/script>\s*<script type="module" crossorigin src="\.\/assets\/index-abc\.js"><\/script>/);
   assert.match(patched, /<script src="\/__webstrapper\/shim\.js"><\/script>/);
+});
+
+test("createAppHostModuleBody resolves RPC peer constructor semantically", () => {
+  const body = createAppHostModuleBody(
+    "/tmp/codex-web/webview/assets/rpc-new.js",
+    "/tmp/codex-web/webview"
+  );
+
+  assert.match(body, /import \* as rpcModule/);
+  assert.match(body, /\[rpcModule\.V, rpcModule\.E, \.\.\.Object\.values\(rpcModule\)\]\.find/);
+  assert.match(body, /getRemoteMain/);
+  assert.doesNotMatch(body, /import \{ E as createRpcPeer \}/);
 });
 
 test("patchStatsigChunkSource makes statsig init non-blocking", () => {


### PR DESCRIPTION
Adds upstream canary and post-build smoke gates so prod/beta repacks fail closed before publish. Includes issue-reporting tests and release workflow ordering checks.