### PR TITLE
fix: guard owl feature binding on linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           cache: npm
 
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools xvfb
+        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools xvfb x11-utils
 
       - name: Install repo deps
         run: npm ci
@@ -126,7 +126,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools xvfb
+        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools xvfb x11-utils
 
       - name: Install repo deps
         run: npm ci
@@ -312,7 +312,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools xvfb
+        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools xvfb x11-utils
 
       - name: Install repo deps
         run: npm ci

--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -23,7 +23,7 @@ jobs:
           cache: npm
 
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools xvfb
+        run: sudo apt-get update && sudo apt-get install -y p7zip-full jq libarchive-tools xvfb x11-utils
 
       - name: Install repo deps
         run: npm ci

--- a/scripts/lib/upstream-patches.mjs
+++ b/scripts/lib/upstream-patches.mjs
@@ -21,6 +21,9 @@ const linuxTransparencyPatchedRegex =
   /transparent:[A-Za-z_$][\w$]*===`linux`\?!1:[A-Za-z_$][\w$]*,hasShadow:/;
 const linuxTransparencyPatchRegex =
   /function ([A-Za-z_$][\w$]*)\(\{alwaysOnTop:([A-Za-z_$][\w$]*),hasShadow:([A-Za-z_$][\w$]*)=!0,platform:([A-Za-z_$][\w$]*),resizable:([A-Za-z_$][\w$]*),thickFrame:([A-Za-z_$][\w$]*),transparent:([A-Za-z_$][\w$]*)=!0\}\)\{return\{frame:!1,transparent:\7,hasShadow:\3,/;
+const owlFeatureBindingRegex =
+  /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=process\._linkedBinding;if\(typeof \2!=`function`\)throw Error\(`Owl feature binding is unavailable`\);return ([A-Za-z_$][\w$]*)\.parse\(\2\.call\(process,`electron_common_owl_features`\)\)\}/;
+const owlFeatureFallbackMarker = "__codexLinuxOwlFeatureFallback";
 
 export class UpstreamPatchContractError extends Error {
   constructor(contractName, message, options = {}) {
@@ -66,6 +69,14 @@ export const upstreamPatchContracts = [
   }
 ];
 
+export const owlFeatureBindingContract = {
+  name: "owl-feature-binding",
+  find: findOwlFeatureBindingPatch,
+  assertBefore: assertOwlFeatureBindingBefore,
+  apply: patchOwlFeatureBinding,
+  assertAfter: assertOwlFeatureBindingAfter
+};
+
 export async function patchUpstreamApp(stageAppDir) {
   const buildDir = path.join(stageAppDir, ".vite", "build");
   const entries = await fs.readdir(buildDir);
@@ -80,10 +91,12 @@ export async function patchUpstreamApp(stageAppDir) {
   const patched = patchUpstreamMainSource(source);
 
   if (patched === source) {
+    await patchOwlFeatureBindingChunks(buildDir, entries);
     return;
   }
 
   await fs.writeFile(mainBundlePath, patched);
+  await patchOwlFeatureBindingChunks(buildDir, entries);
 }
 
 export function patchUpstreamMainSource(source) {
@@ -96,6 +109,10 @@ export function patchLinuxOpenTargetsSource(source) {
 
 export function patchDisableTransparencySource(source) {
   return applyUpstreamPatchContracts(source, upstreamPatchContracts.slice(1));
+}
+
+export function patchLinuxOwlFeatureBindingSource(source) {
+  return applyUpstreamPatchContract(source, owlFeatureBindingContract);
 }
 
 export function applyUpstreamPatchContracts(source, contracts) {
@@ -148,6 +165,80 @@ function applyLinuxOpenTargetsSource(source) {
   patched = patchOpenTargetPlatformLookup(patched);
 
   return patched;
+}
+
+async function patchOwlFeatureBindingChunks(buildDir, entries) {
+  for (const entry of entries) {
+    if (!entry.endsWith(".js")) {
+      continue;
+    }
+
+    const bundlePath = path.join(buildDir, entry);
+    const source = await fs.readFile(bundlePath, "utf8");
+
+    if (!source.includes("electron_common_owl_features")) {
+      continue;
+    }
+
+    const patched = patchLinuxOwlFeatureBindingSource(source);
+
+    if (patched !== source) {
+      await fs.writeFile(bundlePath, patched);
+    }
+  }
+}
+
+function findOwlFeatureBindingPatch(source) {
+  if (source.includes(owlFeatureFallbackMarker)) {
+    return { status: "patched" };
+  }
+
+  const match = source.match(owlFeatureBindingRegex);
+
+  if (!match) {
+    throw new Error("Unable to apply upstream patch; missing Owl feature binding helper");
+  }
+
+  return {
+    status: "patch",
+    anchor: match[0],
+    functionName: match[1],
+    bindingVar: match[2],
+    parserVar: match[3]
+  };
+}
+
+function assertOwlFeatureBindingBefore(source) {
+  const patch = findOwlFeatureBindingPatch(source);
+
+  if (!patch || patch.status !== "patch") {
+    throw new Error("missing unguarded Owl feature binding helper");
+  }
+}
+
+function assertOwlFeatureBindingAfter(source) {
+  if (!source.includes(owlFeatureFallbackMarker)) {
+    throw new Error("missing Linux Owl feature fallback");
+  }
+
+  if (!source.includes("electron_common_owl_features")) {
+    throw new Error("missing Owl feature binding target");
+  }
+}
+
+function patchOwlFeatureBinding(source) {
+  const patch = findOwlFeatureBindingPatch(source);
+
+  if (patch?.status === "patched") {
+    return source;
+  }
+
+  const replacement = [
+    `function ${patch.functionName}(){let ${patch.bindingVar}=process._linkedBinding;if(typeof ${patch.bindingVar}!=\`function\`){if(process.platform===\`linux\`)return ${owlFeatureFallbackMarker}();throw Error(\`Owl feature binding is unavailable\`)}try{return ${patch.parserVar}.parse(${patch.bindingVar}.call(process,\`electron_common_owl_features\`))}catch(e){if(process.platform===\`linux\`&&/electron_common_owl_features|No such binding|Owl feature binding is unavailable/.test(String(e&&e.message||e)))return ${owlFeatureFallbackMarker}();throw e}}`,
+    `function ${owlFeatureFallbackMarker}(){return{isOwlFeatureEnabled:()=>!1}}`
+  ].join("");
+
+  return replaceOnce(source, patch.anchor, replacement);
 }
 
 function assertOpenTargetsBefore(source) {

--- a/scripts/lib/upstream-patches.mjs
+++ b/scripts/lib/upstream-patches.mjs
@@ -112,7 +112,49 @@ export function patchDisableTransparencySource(source) {
 }
 
 export function patchLinuxOwlFeatureBindingSource(source) {
-  return applyUpstreamPatchContract(source, owlFeatureBindingContract);
+  try {
+    let patched = source;
+
+    while (true) {
+      const patch = findOwlFeatureBindingPatch(patched);
+
+      if (patch.status === "patched") {
+        break;
+      }
+
+      patched = patchOwlFeatureBinding(patched, patch);
+    }
+
+    assertOwlFeatureBindingAfter(patched);
+    return patched;
+  } catch (error) {
+    if (error instanceof UpstreamPatchContractError) {
+      throw error;
+    }
+
+    throw new UpstreamPatchContractError(owlFeatureBindingContract.name, error.message, {
+      cause: error
+    });
+  }
+}
+
+export function hasUnguardedOwlFeatureBindingSource(source) {
+  let index = -1;
+
+  while ((index = source.indexOf("electron_common_owl_features", index + 1)) !== -1) {
+    const functionStart = source.lastIndexOf("function ", index);
+    const functionEnd = source.indexOf("function ", index + 1);
+    const bindingScope = source.slice(
+      functionStart === -1 ? Math.max(0, index - 500) : functionStart,
+      functionEnd === -1 ? Math.min(source.length, index + 1000) : functionEnd
+    );
+
+    if (!bindingScope.includes(owlFeatureFallbackMarker)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function applyUpstreamPatchContracts(source, contracts) {
@@ -189,23 +231,27 @@ async function patchOwlFeatureBindingChunks(buildDir, entries) {
 }
 
 function findOwlFeatureBindingPatch(source) {
-  if (source.includes(owlFeatureFallbackMarker)) {
+  const match = source.match(owlFeatureBindingRegex);
+
+  if (match) {
+    return {
+      status: "patch",
+      anchor: match[0],
+      functionName: match[1],
+      bindingVar: match[2],
+      parserVar: match[3]
+    };
+  }
+
+  if (source.includes("electron_common_owl_features") && source.includes(owlFeatureFallbackMarker)) {
     return { status: "patched" };
   }
 
-  const match = source.match(owlFeatureBindingRegex);
-
-  if (!match) {
+  if (source.includes("electron_common_owl_features")) {
     throw new Error("Unable to apply upstream patch; missing Owl feature binding helper");
   }
 
-  return {
-    status: "patch",
-    anchor: match[0],
-    functionName: match[1],
-    bindingVar: match[2],
-    parserVar: match[3]
-  };
+  throw new Error("Unable to apply upstream patch; missing Owl feature binding helper");
 }
 
 function assertOwlFeatureBindingBefore(source) {
@@ -224,18 +270,24 @@ function assertOwlFeatureBindingAfter(source) {
   if (!source.includes("electron_common_owl_features")) {
     throw new Error("missing Owl feature binding target");
   }
+
+  if (hasUnguardedOwlFeatureBindingSource(source)) {
+    throw new Error("unpatched Owl feature binding helper remains");
+  }
 }
 
-function patchOwlFeatureBinding(source) {
-  const patch = findOwlFeatureBindingPatch(source);
+function patchOwlFeatureBinding(source, patch = findOwlFeatureBindingPatch(source)) {
 
   if (patch?.status === "patched") {
     return source;
   }
 
+  const fallback = source.includes(owlFeatureFallbackMarker)
+    ? ""
+    : `function ${owlFeatureFallbackMarker}(){return{isOwlFeatureEnabled:()=>!1}}`;
   const replacement = [
     `function ${patch.functionName}(){let ${patch.bindingVar}=process._linkedBinding;if(typeof ${patch.bindingVar}!=\`function\`){if(process.platform===\`linux\`)return ${owlFeatureFallbackMarker}();throw Error(\`Owl feature binding is unavailable\`)}try{return ${patch.parserVar}.parse(${patch.bindingVar}.call(process,\`electron_common_owl_features\`))}catch(e){if(process.platform===\`linux\`&&/electron_common_owl_features|No such binding|Owl feature binding is unavailable/.test(String(e&&e.message||e)))return ${owlFeatureFallbackMarker}();throw e}}`,
-    `function ${owlFeatureFallbackMarker}(){return{isOwlFeatureEnabled:()=>!1}}`
+    fallback
   ].join("");
 
   return replaceOnce(source, patch.anchor, replacement);

--- a/scripts/smoke-artifacts.mjs
+++ b/scripts/smoke-artifacts.mjs
@@ -6,6 +6,7 @@ import { spawn, spawnSync } from "node:child_process";
 import * as asar from "@electron/asar";
 
 import { channelPaths, getChannel, parseArgs, projectRoot } from "./lib/config.mjs";
+import { hasUnguardedOwlFeatureBindingSource } from "./lib/upstream-patches.mjs";
 
 const nativeExtensions = new Set([
   "",
@@ -16,7 +17,6 @@ const nativeExtensions = new Set([
   ".node",
   ".so"
 ]);
-const owlFeatureFallbackMarker = "__codexLinuxOwlFeatureFallback";
 
 if (isDirectRun()) {
   const args = parseArgs(process.argv.slice(2));
@@ -325,10 +325,7 @@ async function findUnguardedOwlBindingSources(appAsarPath) {
       continue;
     }
 
-    if (
-      source.includes("electron_common_owl_features") &&
-      !source.includes(owlFeatureFallbackMarker)
-    ) {
+    if (hasUnguardedOwlFeatureBindingSource(source)) {
       unsafe.push(file.replace(/^\//, ""));
     }
   }

--- a/scripts/smoke-artifacts.mjs
+++ b/scripts/smoke-artifacts.mjs
@@ -2,7 +2,8 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import process from "node:process";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import * as asar from "@electron/asar";
 
 import { channelPaths, getChannel, parseArgs, projectRoot } from "./lib/config.mjs";
 
@@ -15,6 +16,7 @@ const nativeExtensions = new Set([
   ".node",
   ".so"
 ]);
+const owlFeatureFallbackMarker = "__codexLinuxOwlFeatureFallback";
 
 if (isDirectRun()) {
   const args = parseArgs(process.argv.slice(2));
@@ -59,6 +61,9 @@ export async function smokeLinuxArtifacts({
   );
   await runCheck(summary, "cua_node_repl", () =>
     smokeNodeRepl(path.join(resourcesDir, "cua_node", "bin", "node_repl"))
+  );
+  await runCheck(summary, "owl-runtime-contract", () =>
+    assertOwlRuntimeContract(resourcesDir)
   );
 
   if (packageDir) {
@@ -220,9 +225,13 @@ async function smokeDesktopBinary(executablePath, resourcesDir) {
     env: {
       ...process.env,
       CODEX_CLI_PATH: path.join(resourcesDir, "codex"),
-      ELECTRON_DISABLE_GPU: "1"
+      ELECTRON_DISABLE_GPU: "1",
+      ELECTRON_ENABLE_LOGGING: "1"
     },
-    allowTimeout: true
+    allowTimeout: true,
+    onTimeout: () => ({
+      windowTree: readX11WindowTree()
+    })
   });
 
   return evaluateDesktopBootResult(result);
@@ -230,11 +239,19 @@ async function smokeDesktopBinary(executablePath, resourcesDir) {
 
 export function evaluateDesktopBootResult(result) {
   const combined = `${result.stdout || ""}\n${result.stderr || ""}`;
+  const windowTree = result.windowTree || "";
+  const diagnosticText = `${combined}\n${windowTree}`;
   const reachedBootLog = combined.includes("Launching app") || combined.includes("Codex CLI initialized");
   const fatalOutput = /(Fatal|TypeError|ReferenceError|ErrorBoundary|segmentation fault|core dumped)/i.test(combined);
+  const startupFailureDialog =
+    /failed to start|No such binding was linked|electron_common_owl_features/i.test(windowTree);
 
   if (fatalOutput) {
     throw new Error(`desktop binary printed fatal output: exit=${result.code} output=${combined.slice(0, 600)}`);
+  }
+
+  if (startupFailureDialog) {
+    throw new Error(`desktop binary showed startup failure dialog: exit=${result.code} output=${diagnosticText.slice(0, 1000)}`);
   }
 
   if (result.code && result.code !== 0 && !result.timedOut) {
@@ -248,8 +265,75 @@ export function evaluateDesktopBootResult(result) {
   return {
     exitCode: result.code,
     timedOut: result.timedOut,
-    bootSignal: reachedBootLog ? "log" : result.timedOut ? "alive-timeout" : "clean-exit"
+    bootSignal: reachedBootLog ? "log" : result.timedOut ? "alive-timeout" : "clean-exit",
+    inspectedWindows: Boolean(windowTree)
   };
+}
+
+async function assertOwlRuntimeContract(resourcesDir) {
+  const metadataPath = path.join(resourcesDir, "owl-electron-app.json");
+  let metadata;
+
+  try {
+    metadata = JSON.parse(await fs.readFile(metadataPath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return {
+        runtimeName: null,
+        skipped: true
+      };
+    }
+
+    throw error;
+  }
+
+  if (metadata.runtimeName !== "owl") {
+    return {
+      runtimeName: metadata.runtimeName || null
+    };
+  }
+
+  const appAsarPath = path.join(resourcesDir, "app.asar");
+  const unsafeSources = await findUnguardedOwlBindingSources(appAsarPath);
+
+  if (unsafeSources.length > 0) {
+    throw new Error(
+      `Owl runtime requires electron_common_owl_features, but ${unsafeSources.slice(0, 5).join(", ")} lacks the Linux fallback; stock Electron will show "No such binding was linked: electron_common_owl_features"`
+    );
+  }
+
+  return {
+    runtimeName: metadata.runtimeName,
+    checked: true
+  };
+}
+
+async function findUnguardedOwlBindingSources(appAsarPath) {
+  const files = await asar.listPackage(appAsarPath);
+  const unsafe = [];
+
+  for (const file of files) {
+    if (!/\.(?:js|mjs|cjs)$/i.test(file)) {
+      continue;
+    }
+
+    let source;
+
+    try {
+      source = asar.extractFile(appAsarPath, file.replace(/^\//, "")).toString("utf8");
+    } catch {
+      continue;
+    }
+
+    if (
+      source.includes("electron_common_owl_features") &&
+      !source.includes(owlFeatureFallbackMarker)
+    ) {
+      unsafe.push(file.replace(/^\//, ""));
+    }
+  }
+
+  return unsafe;
 }
 
 async function smokeWebShell({ linuxDir, packageDir, port }) {
@@ -448,6 +532,7 @@ function runCommand(command, args, options = {}) {
     capture = false,
     env = process.env,
     input,
+    onTimeout,
     timeoutMs = 30_000
   } = options;
 
@@ -460,8 +545,10 @@ function runCommand(command, args, options = {}) {
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let timeoutMetadata = {};
     const timer = setTimeout(() => {
       timedOut = true;
+      timeoutMetadata = onTimeout?.() || {};
       child.kill("SIGTERM");
     }, timeoutMs);
 
@@ -487,7 +574,8 @@ function runCommand(command, args, options = {}) {
         code,
         timedOut,
         stdout,
-        stderr
+        stderr,
+        ...timeoutMetadata
       });
     });
 
@@ -495,6 +583,20 @@ function runCommand(command, args, options = {}) {
       child.stdin?.end(input);
     }
   });
+}
+
+function readX11WindowTree() {
+  if (!process.env.DISPLAY) {
+    return "";
+  }
+
+  const result = spawnSync("xwininfo", ["-root", "-tree"], {
+    env: process.env,
+    encoding: "utf8",
+    timeout: 2000
+  });
+
+  return `${result.stdout || ""}\n${result.stderr || ""}`;
 }
 
 function collectProcessOutput(child) {

--- a/test/smoke-artifacts.test.mjs
+++ b/test/smoke-artifacts.test.mjs
@@ -14,7 +14,8 @@ test("desktop boot smoke accepts a silent process still alive at timeout", () =>
     {
       exitCode: null,
       timedOut: true,
-      bootSignal: "alive-timeout"
+      bootSignal: "alive-timeout",
+      inspectedWindows: false
     }
   );
 });
@@ -40,5 +41,18 @@ test("desktop boot smoke still rejects early failed exits", () => {
       stderr: "failed before app ready"
     }),
     /desktop binary exited early/
+  );
+});
+
+test("desktop boot smoke rejects native failed-start dialogs", () => {
+  assert.throws(
+    () => evaluateDesktopBootResult({
+      code: null,
+      timedOut: true,
+      stdout: "",
+      stderr: "",
+      windowTree: '0x200001 "Codex (Beta) failed to start.": ("codex-app-linux-beta-bin" "Codex (Beta)")'
+    }),
+    /desktop binary showed startup failure dialog/
   );
 });

--- a/test/upstream-patches.test.mjs
+++ b/test/upstream-patches.test.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import vm from "node:vm";
 
 import {
+  hasUnguardedOwlFeatureBindingSource,
   patchDisableTransparencySource,
   patchLinuxOwlFeatureBindingSource,
   patchLinuxOpenTargetsSource,
@@ -269,4 +270,28 @@ test("patchLinuxOwlFeatureBindingSource is idempotent", () => {
   const patched = patchLinuxOwlFeatureBindingSource(source);
 
   assert.equal(patchLinuxOwlFeatureBindingSource(patched), patched);
+});
+
+test("patchLinuxOwlFeatureBindingSource patches every Owl binding helper in one bundle", () => {
+  const source = [
+    "let Ge={parse:e=>e},Je={parse:e=>e};",
+    "function Qe(){let e=process._linkedBinding;if(typeof e!=`function`)throw Error(`Owl feature binding is unavailable`);return Ge.parse(e.call(process,`electron_common_owl_features`))}",
+    "function Re(){let t=process._linkedBinding;if(typeof t!=`function`)throw Error(`Owl feature binding is unavailable`);return Je.parse(t.call(process,`electron_common_owl_features`))}"
+  ].join(";");
+
+  const patched = patchLinuxOwlFeatureBindingSource(source);
+
+  assert.equal(hasUnguardedOwlFeatureBindingSource(patched), false);
+  assert.equal(patched.match(/function __codexLinuxOwlFeatureFallback/g).length, 1);
+  assert.equal(patched.match(/return __codexLinuxOwlFeatureFallback\(\)/g).length, 4);
+});
+
+test("hasUnguardedOwlFeatureBindingSource detects mixed patched and unpatched helpers", () => {
+  const mixedSource = [
+    "let Ge={parse:e=>e},Je={parse:e=>e};",
+    "function Qe(){let e=process._linkedBinding;if(typeof e!=`function`){if(process.platform===`linux`)return __codexLinuxOwlFeatureFallback();throw Error(`Owl feature binding is unavailable`)}try{return Ge.parse(e.call(process,`electron_common_owl_features`))}catch(e){if(process.platform===`linux`&&/electron_common_owl_features|No such binding|Owl feature binding is unavailable/.test(String(e&&e.message||e)))return __codexLinuxOwlFeatureFallback();throw e}}function __codexLinuxOwlFeatureFallback(){return{isOwlFeatureEnabled:()=>!1}}",
+    "function Re(){let t=process._linkedBinding;if(typeof t!=`function`)throw Error(`Owl feature binding is unavailable`);return Je.parse(t.call(process,`electron_common_owl_features`))}"
+  ].join(";");
+
+  assert.equal(hasUnguardedOwlFeatureBindingSource(mixedSource), true);
 });

--- a/test/upstream-patches.test.mjs
+++ b/test/upstream-patches.test.mjs
@@ -1,9 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
+import vm from "node:vm";
 
 import {
   patchDisableTransparencySource,
+  patchLinuxOwlFeatureBindingSource,
   patchLinuxOpenTargetsSource,
   upstreamPatchContracts
 } from "../scripts/lib/upstream-patches.mjs";
@@ -232,4 +234,39 @@ test("patchDisableTransparencySource is idempotent", () => {
   const repatched = patchDisableTransparencySource(patched);
 
   assert.equal(repatched, patched);
+});
+
+test("patchLinuxOwlFeatureBindingSource falls back when stock Linux Electron lacks Owl bindings", () => {
+  const source = [
+    "let Ge={parse:e=>e};",
+    "function Ze(e){return Qe().isOwlFeatureEnabled(e)}",
+    "function Qe(){let e=process._linkedBinding;if(typeof e!=`function`)throw Error(`Owl feature binding is unavailable`);return Ge.parse(e.call(process,`electron_common_owl_features`))}",
+    "globalThis.result=Ze(`WorkspaceRootDrop`)"
+  ].join(";");
+
+  const patched = patchLinuxOwlFeatureBindingSource(source);
+  const context = {
+    process: {
+      platform: "linux",
+      _linkedBinding(name) {
+        throw new Error(`No such binding was linked: ${name}`);
+      }
+    },
+    globalThis: {}
+  };
+
+  vm.runInNewContext(patched, context);
+
+  assert.equal(context.globalThis.result, false);
+  assert.match(patched, /__codexLinuxOwlFeatureFallback/);
+});
+
+test("patchLinuxOwlFeatureBindingSource is idempotent", () => {
+  const source = [
+    "let Ge={parse:e=>e};",
+    "function Qe(){let e=process._linkedBinding;if(typeof e!=`function`)throw Error(`Owl feature binding is unavailable`);return Ge.parse(e.call(process,`electron_common_owl_features`))}"
+  ].join(";");
+  const patched = patchLinuxOwlFeatureBindingSource(source);
+
+  assert.equal(patchLinuxOwlFeatureBindingSource(patched), patched);
 });


### PR DESCRIPTION
## Summary
- guard upstream Owl feature binding calls on Linux when stock Electron lacks electron_common_owl_features
- add an owl-runtime-contract smoke gate so Owl runtime bundles with unsafe bindings fail before publish
- inspect X11 window titles during desktop smoke to catch native startup failure dialogs
- install x11-utils in CI so xwininfo is available under Xvfb

## Verification
- npm test
- node scripts/smoke-artifacts.mjs --linux-dir /opt/codex-app-linux-beta --no-browser fails the currently installed broken beta at owl-runtime-contract
- node scripts/canary.mjs --channel beta --no-smoke --json-output /tmp/codex-app-linux-beta-owl-canary.json
- patched beta asar contains zero unsafe electron_common_owl_features chunks
- node scripts/smoke-artifacts.mjs --linux-dir dist/beta/linux-unpacked --package-dir dist/npm/beta/package --json-output /tmp/codex-app-linux-beta-smoke-full.json

closes #16 