### PR TITLE
[codex] restore prod canary for latest upstream

### DIFF
--- a/runtime/webstrap/assets.mjs
+++ b/runtime/webstrap/assets.mjs
@@ -235,7 +235,7 @@ export async function ensureExtractedAssets({
   };
 }
 
-async function findAppHostRpcModulePath(assetsDir) {
+export async function findAppHostRpcModulePath(assetsDir) {
   const entries = await fsp.readdir(assetsDir).catch(() => []);
   for (const entry of entries) {
     if (!/^rpc-.*\.js$/.test(entry)) {
@@ -247,6 +247,22 @@ async function findAppHostRpcModulePath(assetsDir) {
       return filePath;
     }
   }
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".js")) {
+      continue;
+    }
+    const filePath = path.join(assetsDir, entry);
+    const source = await fsp.readFile(filePath, "utf8").catch(() => "");
+    if (
+      source.includes("connect-app-host") &&
+      source.includes("appUpdates") &&
+      source.includes("getRemoteMain")
+    ) {
+      return filePath;
+    }
+  }
+
   return null;
 }
 

--- a/runtime/webstrap/message-router.mjs
+++ b/runtime/webstrap/message-router.mjs
@@ -1182,17 +1182,21 @@ export class MessageRouter {
         case "codex-runtimes-config-changed":
         case "mac-menu-bar-enabled-changed":
         case "electron-avatar-overlay-restore-ready":
+        case "electron-avatar-overlay-feedback-diagnostics-changed":
         case "local-thread-activity-changed":
         case "tray-menu-threads-changed":
         case "avatar-overlay-open-state-request":
         case "keyboard-layout-map-changed":
         case "electron-sparkle-autodownload-changed":
+        case "electron-sparkle-gates-changed":
         case "browser-sidebar-owner-sync":
         case "browser-use-non-local-sites-allowed-changed":
         case "browser-sidebar-tweaks-enabled-changed":
         case "browser-use-session-route-capture":
         case "browser-sidebar-sync":
         case "browser-sidebar-command":
+        case "remote-hosted-pip-active-thread-changed":
+        case "remote-hosted-pip-visibility-changed":
         case "query-cache-invalidate":
         case "electron-desktop-features-changed":
         case "desktop-notification-show":
@@ -1889,6 +1893,7 @@ export class MessageRouter {
           payload = {
             items: [],
             unreadRunCounts: {
+              unreadRuns: [],
               total: 0
             }
           };

--- a/runtime/webstrap/server.mjs
+++ b/runtime/webstrap/server.mjs
@@ -501,18 +501,27 @@ export function createAppHostModuleBody(rpcModulePath, webRoot) {
   const rpcModuleUrl = `/${path.relative(webRoot, rpcModulePath).split(path.sep).join("/")}`;
 
   return `
-import * as rpcModule from ${JSON.stringify(rpcModuleUrl)};
+const rpcModulePromise = import(${JSON.stringify(rpcModuleUrl)});
 
-const createRpcPeer = [rpcModule.V, rpcModule.E, ...Object.values(rpcModule)].find((value) => {
+function resolveCreateRpcPeer(rpcModule) {
+  return [rpcModule.tC, rpcModule.V, rpcModule.E, ...Object.values(rpcModule)].find((value) => {
   if (typeof value !== "function") {
     return false;
   }
 
   return Function.prototype.toString.call(value).includes("getRemoteMain");
-});
+  });
+}
 
-if (typeof createRpcPeer !== "function") {
-  throw new Error("codex-webstrap app host RPC peer constructor not found");
+async function connectAppHostPort(port) {
+  const rpcModule = await rpcModulePromise;
+  const createRpcPeer = resolveCreateRpcPeer(rpcModule);
+
+  if (typeof createRpcPeer !== "function") {
+    throw new Error("codex-webstrap app host RPC peer constructor not found");
+  }
+
+  createRpcPeer(port, appHostMain);
 }
 
 const appUpdateSubscribers = new Set();
@@ -547,7 +556,11 @@ window.addEventListener("message", event => {
     return;
   }
 
-  createRpcPeer(port, appHostMain);
+  connectAppHostPort(port).catch(error => {
+    setTimeout(() => {
+      throw error;
+    });
+  });
 });
 `;
 }

--- a/scripts/lib/upstream-patches.mjs
+++ b/scripts/lib/upstream-patches.mjs
@@ -2,18 +2,19 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { parse } from "acorn";
 
-const linuxOpenTargetDefinitions = openCommandName => [
+const linuxOpenTargetDefinitions = ({ openCommandName, executableResolverName }) => [
   "var __codexLinuxOpenTargetGotoArgs=(e,t)=>t?[`--goto`,`${e}:${t.line}:${t.column}`]:[e]",
   "__codexLinuxOpenTargetColonArgs=(e,t)=>t?[`${e}:${t.line}:${t.column}`]:[e]",
-  "__codexLinuxOpenTargetTerminal=()=>{let e=process.env.TERMINAL?.trim();if(e&&W(e))return{command:W(e),args:e=>[`-e`,process.env.SHELL?.trim()||`/bin/sh`,`-lc`,e]};for(let e of [[`ghostty`,e=>[`-e`,process.env.SHELL?.trim()||`/bin/sh`,`-lc`,e]],[`kitty`,e=>[`-e`,process.env.SHELL?.trim()||`/bin/sh`,`-lc`,e]],[`alacritty`,e=>[`-e`,process.env.SHELL?.trim()||`/bin/sh`,`-lc`,e]],[`wezterm`,e=>[`start`,`--`,process.env.SHELL?.trim()||`/bin/sh`,`-lc`,e]],[`gnome-terminal`,e=>[`--`,process.env.SHELL?.trim()||`/bin/sh`,`-lc`,e]],[`konsole`,e=>[`-e`,process.env.SHELL?.trim()||`/bin/sh`,`-lc`,e]],[`xterm`,e=>[`-e`,process.env.SHELL?.trim()||`/bin/sh`,`-lc`,e]]]){let t=W(e[0]);if(t)return{command:t,args:e[1]}}return null}",
+  `__codexLinuxOpenTargetTerminal=()=>{let e=process.env.TERMINAL?.trim();if(e&&${executableResolverName}(e))return{command:${executableResolverName}(e),args:e=>[\`-e\`,process.env.SHELL?.trim()||\`/bin/sh\`,\`-lc\`,e]};for(let e of [[\`ghostty\`,e=>[\`-e\`,process.env.SHELL?.trim()||\`/bin/sh\`,\`-lc\`,e]],[\`kitty\`,e=>[\`-e\`,process.env.SHELL?.trim()||\`/bin/sh\`,\`-lc\`,e]],[\`alacritty\`,e=>[\`-e\`,process.env.SHELL?.trim()||\`/bin/sh\`,\`-lc\`,e]],[\`wezterm\`,e=>[\`start\`,\`--\`,process.env.SHELL?.trim()||\`/bin/sh\`,\`-lc\`,e]],[\`gnome-terminal\`,e=>[\`--\`,process.env.SHELL?.trim()||\`/bin/sh\`,\`-lc\`,e]],[\`konsole\`,e=>[\`-e\`,process.env.SHELL?.trim()||\`/bin/sh\`,\`-lc\`,e]],[\`xterm\`,e=>[\`-e\`,process.env.SHELL?.trim()||\`/bin/sh\`,\`-lc\`,e]]]){let t=${executableResolverName}(e[0]);if(t)return{command:t,args:e[1]}}return null}`,
   "__codexLinuxOpenTargetNvimArgs=(e,t)=>t?[`+call cursor(${t.line},${t.column})`,e]:[e]",
-  "__codexLinuxOpenTargetNvimCommand=(e,n,r)=>`${t.En(e)} ${t.Tn(__codexLinuxOpenTargetNvimArgs(n,r))}`",
+  "__codexLinuxShellQuote=e=>{e=String(e);return e.length===0?`''`:/^[A-Za-z0-9_/:=.-]+$/.test(e)?e:`'${e.replaceAll(`'`,`'\\\\''`)}'`}",
+  "__codexLinuxOpenTargetNvimCommand=(e,n,r)=>[e,...__codexLinuxOpenTargetNvimArgs(n,r)].map(__codexLinuxShellQuote).join(` `)",
   `__codexLinuxOpenTargetRunNvim=async({command:e,path:t,location:n})=>{let r=__codexLinuxOpenTargetTerminal();if(!r)throw Error(\`No terminal emulator found for Neovim\`);await ${openCommandName}(r.command,r.args(__codexLinuxOpenTargetNvimCommand(e,t,n)))}`,
-  "__codexLinuxVSCode={id:`vscode`,platforms:{linux:{label:`VS Code`,icon:`apps/vscode.png`,kind:`editor`,detect:()=>W(`code`),args:__codexLinuxOpenTargetGotoArgs}}}",
-  "__codexLinuxVSCodeInsiders={id:`vscodeInsiders`,platforms:{linux:{label:`VS Code Insiders`,icon:`apps/vscode-insiders.png`,kind:`editor`,detect:()=>W(`code-insiders`),args:__codexLinuxOpenTargetGotoArgs}}}",
-  "__codexLinuxCursor={id:`cursor`,platforms:{linux:{label:`Cursor`,icon:`apps/cursor.png`,kind:`editor`,detect:()=>W(`cursor`),args:__codexLinuxOpenTargetGotoArgs}}}",
-  "__codexLinuxZed={id:`zed`,platforms:{linux:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:()=>W(`zed`),args:__codexLinuxOpenTargetColonArgs}}}",
-  "__codexLinuxNvim={id:`nvim`,platforms:{linux:{label:`Neovim`,icon:`apps/terminal.png`,kind:`editor`,detect:()=>W(`nvim`),args:__codexLinuxOpenTargetNvimArgs,open:__codexLinuxOpenTargetRunNvim}}}"
+  `__codexLinuxVSCode={id:\`vscode\`,platforms:{linux:{label:\`VS Code\`,icon:\`apps/vscode.png\`,kind:\`editor\`,detect:()=>${executableResolverName}(\`code\`),args:__codexLinuxOpenTargetGotoArgs}}}`,
+  `__codexLinuxVSCodeInsiders={id:\`vscodeInsiders\`,platforms:{linux:{label:\`VS Code Insiders\`,icon:\`apps/vscode-insiders.png\`,kind:\`editor\`,detect:()=>${executableResolverName}(\`code-insiders\`),args:__codexLinuxOpenTargetGotoArgs}}}`,
+  `__codexLinuxCursor={id:\`cursor\`,platforms:{linux:{label:\`Cursor\`,icon:\`apps/cursor.png\`,kind:\`editor\`,detect:()=>${executableResolverName}(\`cursor\`),args:__codexLinuxOpenTargetGotoArgs}}}`,
+  `__codexLinuxZed={id:\`zed\`,platforms:{linux:{label:\`Zed\`,icon:\`apps/zed.png\`,kind:\`editor\`,detect:()=>${executableResolverName}(\`zed\`),args:__codexLinuxOpenTargetColonArgs}}}`,
+  `__codexLinuxNvim={id:\`nvim\`,platforms:{linux:{label:\`Neovim\`,icon:\`apps/terminal.png\`,kind:\`editor\`,detect:()=>${executableResolverName}(\`nvim\`),args:__codexLinuxOpenTargetNvimArgs,open:__codexLinuxOpenTargetRunNvim}}}`
 ].join(",");
 const openTargetMapRegex =
   /targets:\[\.\.\.([A-Za-z_$][\w$]*)\.map\(\(\{id:([A-Za-z_$][\w$]*),label:([A-Za-z_$][\w$]*),icon:([A-Za-z_$][\w$]*),kind:([A-Za-z_$][\w$]*),hidden:([A-Za-z_$][\w$]*)\}\)=>\(\{id:\2,target:\2,label:\3,icon:\4,kind:\5,hidden:\6,available:([A-Za-z_$][\w$]*)\.has\(\2\),default:([A-Za-z_$][\w$]*)===\2\|\|void 0\}\)\),\.\.\.([A-Za-z_$][\w$]*)\]/;
@@ -23,6 +24,8 @@ const linuxTransparencyPatchRegex =
   /function ([A-Za-z_$][\w$]*)\(\{alwaysOnTop:([A-Za-z_$][\w$]*),hasShadow:([A-Za-z_$][\w$]*)=!0,platform:([A-Za-z_$][\w$]*),resizable:([A-Za-z_$][\w$]*),thickFrame:([A-Za-z_$][\w$]*),transparent:([A-Za-z_$][\w$]*)=!0\}\)\{return\{frame:!1,transparent:\7,hasShadow:\3,/;
 const owlFeatureBindingRegex =
   /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=process\._linkedBinding;if\(typeof \2!=`function`\)throw Error\(`Owl feature binding is unavailable`\);return ([A-Za-z_$][\w$]*)\.parse\(\2\.call\(process,`electron_common_owl_features`\)\)\}/;
+const owlNullableFeatureBindingRegex =
+  /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=process\._linkedBinding;if\(typeof \2!=`function`\)return null;let ([A-Za-z_$][\w$]*);try\{\3=\2\.call\(process,([A-Za-z_$][\w$]*)\)\}catch\(([A-Za-z_$][\w$]*)\)\{if\(([A-Za-z_$][\w$]*)\(\5\)\)return null;throw \5\}return ([A-Za-z_$][\w$]*)\.parse\(\3\)\}/;
 const owlFeatureFallbackMarker = "__codexLinuxOwlFeatureFallback";
 const dynamicToolSchemaContractMarker = "__codexLinuxDynamicToolSchemaContract";
 const dynamicToolStartResponseMarker = "__codexLinuxNormalizeDynamicToolsForThreadStart";
@@ -218,6 +221,10 @@ export function hasUnguardedOwlFeatureBindingSource(source) {
       functionEnd === -1 ? Math.min(source.length, index + 1000) : functionEnd
     );
 
+    if (!bindingScope.includes("process._linkedBinding")) {
+      continue;
+    }
+
     if (!bindingScope.includes(owlFeatureFallbackMarker)) {
       return true;
     }
@@ -291,7 +298,7 @@ function applyLinuxOpenTargetsSource(source) {
     patched = replaceOnce(
       patched,
       openTargets.anchor,
-      `${linuxOpenTargetDefinitions(openTargets.openCommandName)};${openTargets.anchor.replace("[", "[__codexLinuxVSCode,__codexLinuxVSCodeInsiders,__codexLinuxCursor,__codexLinuxZed,__codexLinuxNvim,")}`
+      `${linuxOpenTargetDefinitions(openTargets)};${openTargets.anchor.replace("[", "[__codexLinuxVSCode,__codexLinuxVSCodeInsiders,__codexLinuxCursor,__codexLinuxZed,__codexLinuxNvim,")}`
     );
   }
 
@@ -405,10 +412,28 @@ function findOwlFeatureBindingPatch(source) {
   if (match) {
     return {
       status: "patch",
+      patchKind: "throwing",
       anchor: match[0],
       functionName: match[1],
       bindingVar: match[2],
       parserVar: match[3]
+    };
+  }
+
+  const nullableMatch = source.match(owlNullableFeatureBindingRegex);
+
+  if (nullableMatch) {
+    return {
+      status: "patch",
+      patchKind: "nullable",
+      anchor: nullableMatch[0],
+      functionName: nullableMatch[1],
+      bindingVar: nullableMatch[2],
+      resultVar: nullableMatch[3],
+      featureTargetVar: nullableMatch[4],
+      errorVar: nullableMatch[5],
+      safeErrorFunctionName: nullableMatch[6],
+      parserVar: nullableMatch[7]
     };
   }
 
@@ -1004,6 +1029,15 @@ function patchOwlFeatureBinding(source, patch = findOwlFeatureBindingPatch(sourc
   const fallback = source.includes(owlFeatureFallbackMarker)
     ? ""
     : `function ${owlFeatureFallbackMarker}(){return{isOwlFeatureEnabled:()=>!1}}`;
+  if (patch.patchKind === "nullable") {
+    const replacement = [
+      `function ${patch.functionName}(){let ${patch.bindingVar}=process._linkedBinding;if(typeof ${patch.bindingVar}!=\`function\`){if(process.platform===\`linux\`)return ${owlFeatureFallbackMarker}();return null}let ${patch.resultVar};try{${patch.resultVar}=${patch.bindingVar}.call(process,${patch.featureTargetVar})}catch(${patch.errorVar}){if(process.platform===\`linux\`&&(${patch.safeErrorFunctionName}(${patch.errorVar})||/electron_common_owl_features|No such binding|Owl feature binding is unavailable/.test(String(${patch.errorVar}&&${patch.errorVar}.message||${patch.errorVar}))))return ${owlFeatureFallbackMarker}();if(${patch.safeErrorFunctionName}(${patch.errorVar}))return null;throw ${patch.errorVar}}try{return ${patch.parserVar}.parse(${patch.resultVar})}catch(${patch.errorVar}){if(process.platform===\`linux\`&&/electron_common_owl_features|No such binding|Owl feature binding is unavailable/.test(String(${patch.errorVar}&&${patch.errorVar}.message||${patch.errorVar})))return ${owlFeatureFallbackMarker}();throw ${patch.errorVar}}}`,
+      fallback
+    ].join("");
+
+    return replaceOnce(source, patch.anchor, replacement);
+  }
+
   const replacement = [
     `function ${patch.functionName}(){let ${patch.bindingVar}=process._linkedBinding;if(typeof ${patch.bindingVar}!=\`function\`){if(process.platform===\`linux\`)return ${owlFeatureFallbackMarker}();throw Error(\`Owl feature binding is unavailable\`)}try{return ${patch.parserVar}.parse(${patch.bindingVar}.call(process,\`electron_common_owl_features\`))}catch(e){if(process.platform===\`linux\`&&/electron_common_owl_features|No such binding|Owl feature binding is unavailable/.test(String(e&&e.message||e)))return ${owlFeatureFallbackMarker}();throw e}}`,
     fallback
@@ -1470,7 +1504,7 @@ function patchOpenTargetPlatformLookup(source) {
 
 function findOpenTargetRegistry(source) {
   const match = source.match(
-    /var ([A-Za-z_$][\w$]*)=\[[^\]]+\],[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\(`open-in-targets`\);\s*function [A-Za-z_$][\w$]*\(e\)\{return \1\.flatMap/
+    /var ([A-Za-z_$][\w$]*)=\[[^\]]+\](?:,[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\(`open-in-targets`\)|\s*;[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\(`open-in-targets`\));\s*function [A-Za-z_$][\w$]*\(e\)\{return \1\.flatMap/
   );
 
   if (!match) {
@@ -1481,8 +1515,29 @@ function findOpenTargetRegistry(source) {
 
   return {
     anchor,
-    openCommandName: findOpenCommandName(source)
+    openCommandName: findOpenCommandName(source),
+    executableResolverName: findOpenExecutableResolverName(source)
   };
+}
+
+function findOpenExecutableResolverName(source) {
+  const resolverMatch = source.match(
+    /function ([A-Za-z_$][\w$]*)\(e\)\{let [A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\.default\.sync\(e,\{nothrow:!0\}\);return typeof [A-Za-z_$][\w$]*==`string`&&/
+  );
+
+  if (resolverMatch) {
+    return resolverMatch[1];
+  }
+
+  const targetDetectMatch = source.match(
+    /([A-Za-z_$][\w$]*)\(`(?:code|code-insiders|cursor|zed|nvim)`\)/
+  );
+
+  if (targetDetectMatch) {
+    return targetDetectMatch[1];
+  }
+
+  throw new Error("Unable to apply upstream patch; missing open target executable resolver");
 }
 
 function findOpenCommandName(source) {

--- a/test/message-router.test.mjs
+++ b/test/message-router.test.mjs
@@ -87,6 +87,18 @@ test("MessageRouter ignores electron-only startup pings in web mode", async () =
     }
   });
 
+  for (const type of [
+    "remote-hosted-pip-visibility-changed",
+    "remote-hosted-pip-active-thread-changed",
+    "electron-avatar-overlay-feedback-diagnostics-changed",
+    "electron-sparkle-gates-changed"
+  ]) {
+    await router.handleEnvelope(ws, {
+      type: "view-message",
+      payload: { type }
+    });
+  }
+
   assert.deepEqual(sent, []);
 
   router.dispose();
@@ -498,6 +510,7 @@ test("MessageRouter provides browser-safe virtual fetch defaults", async () => {
   assert.deepEqual(JSON.parse(sent[3].payload.bodyJsonString), {
     items: [],
     unreadRunCounts: {
+      unreadRuns: [],
       total: 0
     }
   });

--- a/test/upstream-patches.test.mjs
+++ b/test/upstream-patches.test.mjs
@@ -23,15 +23,19 @@ import {
   dynamicToolThreadStartRequestContract
 } from "../scripts/lib/upstream-patches.mjs";
 
+const openTargetResolverSource =
+  "function W(e){let t=which.default.sync(e,{nothrow:!0});return typeof t==`string`&&fs.existsSync(t)?t:null}";
+const withOpenTargetResolver = parts => [openTargetResolverSource, ...parts].join(";");
+
 test("patchLinuxOpenTargetsSource adds Linux editor targets and exposes app paths", () => {
-  const source = [
+  const source = withOpenTargetResolver([
     "prefix",
     "var wd=[nd,id,ed,ou,Ll,Wu,vd,sd,Fl,vu,qu,uu,zl,hu,iu,ld,bu,mu,od,pd,Eu,Du,Ou,ku,Au,ju,Mu,Nu,Xu],Td=t.kr(`open-in-targets`);function Ed(e){return wd.flatMap(t=>{let n=t.platforms[e];return n?[{id:t.id,...n}]:[]})}",
     "async function Fd(e,t,n,r,i,a,o){let s={args:()=>[],env:()=>({})},c=`open`;await ol(c,s.args(t,r,i,a,o),{env:s.env?.()})}",
     "middle",
     "targets:[...o.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:s.has(e),default:c===e||void 0})),...p]",
     "suffix"
-  ].join(";");
+  ]);
 
   const patched = patchLinuxOpenTargetsSource(source);
 
@@ -56,11 +60,11 @@ test("patchLinuxOpenTargetsSource adds Linux editor targets and exposes app path
 });
 
 test("patchLinuxOpenTargetsSource is idempotent for target definitions", () => {
-  const source = [
+  const source = withOpenTargetResolver([
     "var wd=[nd,id,ed,ou,Ll,Wu,vd,sd,Fl,vu,qu,uu,zl,hu,iu,ld,bu,mu,od,pd,Eu,Du,Ou,ku,Au,ju,Mu,Nu,Xu],Td=t.kr(`open-in-targets`);function Ed(e){return wd.flatMap(t=>{let n=t.platforms[e];return n?[{id:t.id,...n}]:[]})}",
     "async function Fd(e,t,n,r,i,a,o){let s={args:()=>[],env:()=>({})},c=`open`;await ol(c,s.args(t,r,i,a,o),{env:s.env?.()})}",
     "targets:[...o.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:s.has(e),default:c===e||void 0})),...p]"
-  ].join(";");
+  ]);
 
   const patched = patchLinuxOpenTargetsSource(source);
   const repatched = patchLinuxOpenTargetsSource(patched);
@@ -69,11 +73,11 @@ test("patchLinuxOpenTargetsSource is idempotent for target definitions", () => {
 });
 
 test("patchLinuxOpenTargetsSource accepts alternate minified logger names", () => {
-  const source = [
+  const source = withOpenTargetResolver([
     "var Cd=[td,rd,$u,au,Il,Uu,_d,od,Pl,_u,Ku,lu,Rl,mu,ru,cd,yu,pu,ad,fd,Tu,Eu,Du,Ou,ku,Au,ju,Mu,Yu],wd=t.Or(`open-in-targets`);function Td(e){return Cd.flatMap(t=>{let n=t.platforms[e];return n?[{id:t.id,...n}]:[]})}",
     "async function Pd(e,t,n,r,i,a,o){let s={args:()=>[],env:()=>({})},c=`open`;await ol(c,s.args(t,r,i,a,o),{env:s.env?.()})}",
     "targets:[...o.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:s.has(e),default:c===e||void 0})),...p]"
-  ].join(";");
+  ]);
 
   const patched = patchLinuxOpenTargetsSource(source);
 
@@ -84,11 +88,11 @@ test("patchLinuxOpenTargetsSource accepts alternate minified logger names", () =
 });
 
 test("patchLinuxOpenTargetsSource accepts upstream electron 42 registry shape", () => {
-  const source = [
+  const source = withOpenTargetResolver([
     "var Wk=[Tk,Dk,Ck,OO,aO,MO,pk,Vk,Ak,rO,VO,gk,NO,sO,RO,EO,Mk,UO,LO,kk,Ik,YO,XO,ZO,QO,$O,ek,tk,nk,yk],Gk=n.Rr(`open-in-targets`);function Kk(e){return Wk.flatMap(t=>{let n=t.platforms[e];return n?[{id:t.id,...n}]:[]})}",
     "async function tA(e,t,n,r,i,a,o){let s={args:()=>[],env:()=>({})},c=`open`;await vo(c,s.args(t,r,i,a,o),{env:s.env?.()})}",
     "targets:[...s.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:c.has(e),default:l===e||void 0})),...g]"
-  ].join(";");
+  ]);
 
   const patched = patchLinuxOpenTargetsSource(source);
 
@@ -103,11 +107,11 @@ test("patchLinuxOpenTargetsSource accepts upstream electron 42 registry shape", 
 });
 
 test("patchLinuxOpenTargetsSource accepts upstream dispatcher runner shape", () => {
-  const source = [
+  const source = withOpenTargetResolver([
     "var kN=[cN,uN,oN,lM],AN=t.qr(`open-in-targets`);function jN(e){return kN.flatMap(t=>{let n=t.platforms[e];return n?[{id:t.id,...n}]:[]})}",
     "async function BN(e,t,{appPath:n,detectedCommand:r,hostConfig:i,location:a,remotePath:o,remoteWorkspaceRoot:s,targets:c=MN}={}){if(o!=null&&i?.kind===`remote-control`)throw Error(`Remote control does not support open in ${e} yet.`);let l=c.find(t=>t.id===e);if(!l)throw Error(`Unknown open target \"${e}\"`);let u=r??await l.detect(IN);if(!u)throw Error(`Open target \"${e}\" is not available`);if(l.open){await l.open({command:u,path:t,appPath:n,location:a,hostConfig:i,remoteWorkspaceRoot:s,remotePath:o});return}await no(u,l.args(t,a,i,s,o),{env:l.env?.()})}",
     "targets:[...s.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:c.has(e),default:l===e||void 0})),...g]"
-  ].join(";");
+  ]);
 
   const patched = patchLinuxOpenTargetsSource(source);
 
@@ -118,6 +122,29 @@ test("patchLinuxOpenTargetsSource accepts upstream dispatcher runner shape", () 
   assert.match(
     patched,
     /await no\(r\.command,r\.args\(__codexLinuxOpenTargetNvimCommand\(e,t,n\)\)\)/
+  );
+});
+
+test("patchLinuxOpenTargetsSource accepts bare open-target logger and discovered resolver", () => {
+  const source = [
+    "function os(e){let t=rs.default.sync(e,{nothrow:!0});return typeof t==`string`&&u.existsSync(t)?t:null}",
+    "var GN=[wN,EN,SN,TM,nM,kM,fN,BN,kN,eM,RM,hN,AM,iM,FM,CM,jN,BM,PM,ON,FN,KM,qM,JM,YM,XM,ZM,QM,$M,vN];t.ri(`open-in-targets`);function KN(e){return GN.flatMap(t=>{let n=t.platforms[e];return n?[{id:t.id,...n}]:[]})}",
+    "async function XN(e,t,{appPath:n,detectedCommand:r,hostConfig:i,location:a,remotePath:o,remoteWorkspaceRoot:s,targets:c=qN}={}){if(o!=null&&i?.kind===`remote-control`)throw Error(`Remote control does not support open in ${e} yet.`);let l=c.find(t=>t.id===e);if(!l)throw Error(`Unknown open target \"${e}\"`);let u=r??await l.detect(JN);if(!u)throw Error(`Open target \"${e}\" is not available`);if(l.open){await l.open({command:u,path:t,appPath:n,location:a,hostConfig:i,remoteWorkspaceRoot:s,remotePath:o});return}await us(u,l.args(t,a,i,s,o),{env:l.env?.()})}",
+    "targets:[...l.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:m.has(e),default:h===e||void 0})),...y]"
+  ].join(";");
+
+  const patched = patchLinuxOpenTargetsSource(source);
+
+  assert.match(
+    patched,
+    /var GN=\[__codexLinuxVSCode,__codexLinuxVSCodeInsiders,__codexLinuxCursor,__codexLinuxZed,__codexLinuxNvim,wN,EN/
+  );
+  assert.match(patched, /detect:\(\)=>os\(`code`\)/);
+  assert.match(patched, /__codexLinuxShellQuote=/);
+  assert.doesNotMatch(patched, /t\.En/);
+  assert.match(
+    patched,
+    /appPath:process\.platform===`linux`&&r===`editor`&&m\.has\(e\)\?Ld\(\)\.get\(e\)\?\?null:null/
   );
 });
 
@@ -188,11 +215,11 @@ test("patchLinuxOpenTargetsSource reports contract name on upstream drift", () =
 });
 
 test("patchLinuxOpenTargetsSource tolerates targets without platform maps", () => {
-  const source = [
+  const source = withOpenTargetResolver([
     "var wd=[nd,id],Td=t.kr(`open-in-targets`);function Ed(e){return wd.flatMap(t=>{let n=t.platforms[e];return n?[{id:t.id,...n}]:[]})}",
     "async function Fd(e,t,n,r,i,a,o){let s={args:()=>[],env:()=>({})},c=`open`;await ol(c,s.args(t,r,i,a,o),{env:s.env?.()})}",
     "targets:[...o.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:s.has(e),default:c===e||void 0})),...p]"
-  ].join(";");
+  ]);
 
   const patched = patchLinuxOpenTargetsSource(source);
 
@@ -200,11 +227,11 @@ test("patchLinuxOpenTargetsSource tolerates targets without platform maps", () =
 });
 
 test("patchLinuxOpenTargetsSource preserves native target spread variable", () => {
-  const source = [
+  const source = withOpenTargetResolver([
     "var uD=[HE,WE],dD=t.ti(`open-in-targets`);function fD(e){return uD.flatMap(t=>{let n=t.platforms[e];return n?[{id:t.id,...n}]:[]})}",
     "async function xD(e,t,n,r,i,a,o){let s={args:()=>[],env:()=>({})},c=`open`;await zi(c,s.args(t,r,i,a,o),{env:s.env?.()})}",
     "targets:[...o.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:s.has(e),default:c===e||void 0})),...h]"
-  ].join(";");
+  ]);
 
   const patched = patchLinuxOpenTargetsSource(source);
 
@@ -297,6 +324,30 @@ test("patchLinuxOwlFeatureBindingSource falls back when stock Linux Electron lac
   vm.runInNewContext(patched, context);
 
   assert.equal(context.globalThis.result, false);
+  assert.match(patched, /__codexLinuxOwlFeatureFallback/);
+});
+
+test("patchLinuxOwlFeatureBindingSource accepts nullable Owl helper shape", () => {
+  const source = [
+    "let Ve=`electron_common_owl_features`,Ge={parse:e=>e};",
+    "function st(e){return e instanceof Error?e.message.includes(Ve)&&e.message.includes(`No such binding was linked:`):!1}",
+    "function Ze(e){let t=Qe();return t==null?!1:t.isOwlFeatureEnabled(e)}",
+    "function Qe(){let e=process._linkedBinding;if(typeof e!=`function`)return null;let t;try{t=e.call(process,Ve)}catch(e){if(st(e))return null;throw e}return Ge.parse(t)}",
+    "globalThis.result=Ze(`WorkspaceRootDrop`)"
+  ].join(";");
+
+  const patched = patchLinuxOwlFeatureBindingSource(source);
+  const context = {
+    process: {
+      platform: "linux"
+    },
+    globalThis: {}
+  };
+
+  vm.runInNewContext(patched, context);
+
+  assert.equal(context.globalThis.result, false);
+  assert.equal(hasUnguardedOwlFeatureBindingSource(patched), false);
   assert.match(patched, /__codexLinuxOwlFeatureFallback/);
 });
 

--- a/test/web-assets.test.mjs
+++ b/test/web-assets.test.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 import {
   buildPatchedIndexHtml,
   defaultAllowedLocalAssetRoots,
+  findAppHostRpcModulePath,
   patchStatsigChunkSource,
   readAllowedLocalAssetFile,
   readBuildMetadata,
@@ -114,10 +115,32 @@ test("createAppHostModuleBody resolves RPC peer constructor semantically", () =>
     "/tmp/codex-web/webview"
   );
 
-  assert.match(body, /import \* as rpcModule/);
-  assert.match(body, /\[rpcModule\.V, rpcModule\.E, \.\.\.Object\.values\(rpcModule\)\]\.find/);
+  assert.match(body, /const rpcModulePromise = import/);
+  assert.match(body, /\[rpcModule\.tC, rpcModule\.V, rpcModule\.E, \.\.\.Object\.values\(rpcModule\)\]\.find/);
   assert.match(body, /getRemoteMain/);
   assert.doesNotMatch(body, /import \{ E as createRpcPeer \}/);
+});
+
+test("findAppHostRpcModulePath accepts upstream rpc facade layout", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-app-linux-rpc-assets-"));
+  const assetsDir = path.join(root, "assets");
+  await fs.mkdir(assetsDir);
+  await fs.writeFile(
+    path.join(assetsDir, "rpc-new.js"),
+    "import{bS as e,vS as t,xS as n,yS as r}from './app-initial.js';e();export{t as appHost,r as appServices,n as initializeAppHostServices};"
+  );
+  const appInitialPath = path.join(assetsDir, "app-initial.js");
+  await fs.writeFile(
+    appInitialPath,
+    [
+      "function peer(port,target){return new Rpc(port,target).getRemoteMain()}",
+      "function connect(){window.postMessage({type:`connect-app-host`},window.location.origin)}",
+      "const services={appUpdates:{stateChanged(){}}}",
+      "export{peer as tC}"
+    ].join(";")
+  );
+
+  assert.equal(await findAppHostRpcModulePath(assetsDir), appInitialPath);
 });
 
 test("patchStatsigChunkSource makes statsig init non-blocking", () => {


### PR DESCRIPTION
## Summary
- restore Linux open-target patching for latest prod minifier shape and discovered executable resolver
- support latest nullable Owl binding helper and web RPC facade layout
- fix browser shell startup data/no-op messages for latest web bundle
- add regressions for the upstream drift cases

## Root Cause
Latest prod moved the open-target registry/logger shape, renamed the executable resolver, changed Owl binding helper behavior, made the web RPC module a facade over the main app chunk, and started requiring `unreadRunCounts.unreadRuns` during browser boot.

## Validation
- `npm test`
- `node scripts/smoke-artifacts.mjs --channel prod`
- `node scripts/canary.mjs --channel prod --json-output dist/upstream-canary-prod.json`

Closes #21
Closes #22
Closes #23
Closes #24
Closes #25
Closes #26
