### PR TITLE
Fix 26.707 packaging and align the Linux runtime

### DIFF
--- a/electron-builder.config.mjs
+++ b/electron-builder.config.mjs
@@ -30,9 +30,6 @@ export default {
   electronVersion,
   npmRebuild: false,
   buildDependenciesFromSource: false,
-  extraMetadata: {
-    main: ".vite/build/bootstrap.js"
-  },
   asar: true,
   files: [
     {

--- a/scripts/lib/build.mjs
+++ b/scripts/lib/build.mjs
@@ -23,6 +23,7 @@ const skippedLinuxResourceNames = new Set([
   "app.asar",
   "app.asar.unpacked",
   "codex",
+  "codex-code-mode-host",
   "codex_chronicle",
   "cua_node",
   "native",
@@ -44,11 +45,12 @@ const primaryRuntime = {
 const codexCliRuntime = {
   url:
     process.env.CODEX_CLI_RUNTIME_URL ||
-    "https://github.com/openai/codex/releases/download/rust-v0.140.0/codex-package-x86_64-unknown-linux-musl.tar.gz",
+    "https://github.com/openai/codex/releases/download/rust-v0.144.0-alpha.4/codex-package-x86_64-unknown-linux-musl.tar.gz",
   sha256:
     process.env.CODEX_CLI_RUNTIME_SHA256 ||
-    "9620e798900c6fb289199a9e0a8ed0c3a8cb7e3561048498ebc2dac354a1627b",
-  codexEntry: "bin/codex"
+    "d445749123af97de7e2adf8d66fc52954c8c15d692d19f4cb3d6bd12aafa37ba",
+  codexEntry: "bin/codex",
+  codeModeHostEntry: "bin/codex-code-mode-host"
 };
 
 export async function buildChannel({
@@ -574,10 +576,23 @@ export async function stageLinuxCodexCliRuntime(targetDir) {
   );
   const extractDir = path.join(targetDir, ".codex-cli-runtime-extract");
   const sourceCodex = path.join(extractDir, "bin", "codex");
+  const sourceCodeModeHost = path.join(extractDir, "bin", "codex-code-mode-host");
 
   await ensureEmptyDir(extractDir);
-  await run(["tar", "-xzf", archivePath, "-C", extractDir, codexCliRuntime.codexEntry]);
+  await run([
+    "tar",
+    "-xzf",
+    archivePath,
+    "-C",
+    extractDir,
+    codexCliRuntime.codexEntry,
+    codexCliRuntime.codeModeHostEntry
+  ]);
   await installLinuxRuntimeExecutable(sourceCodex, path.join(targetDir, "codex"));
+  await installLinuxRuntimeExecutable(
+    sourceCodeModeHost,
+    path.join(targetDir, "codex-code-mode-host")
+  );
   await fs.rm(extractDir, { recursive: true, force: true });
 }
 

--- a/scripts/lib/upstream-patches.mjs
+++ b/scripts/lib/upstream-patches.mjs
@@ -27,10 +27,6 @@ const owlFeatureBindingRegex =
 const owlNullableFeatureBindingRegex =
   /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=process\._linkedBinding;if\(typeof \2!=`function`\)return null;let ([A-Za-z_$][\w$]*);try\{\3=\2\.call\(process,([A-Za-z_$][\w$]*)\)\}catch\(([A-Za-z_$][\w$]*)\)\{if\(([A-Za-z_$][\w$]*)\(\5\)\)return null;throw \5\}return ([A-Za-z_$][\w$]*)\.parse\(\3\)\}/;
 const owlFeatureFallbackMarker = "__codexLinuxOwlFeatureFallback";
-const dynamicToolSchemaContractMarker = "__codexLinuxDynamicToolSchemaContract";
-const dynamicToolStartResponseMarker = "__codexLinuxNormalizeDynamicToolsForThreadStart";
-const dynamicToolThreadStartRequestMarker = "__codexLinuxNormalizeThreadStartRequestParams";
-const dynamicToolThreadStartBridgeMarker = "__codexLinuxNormalizeThreadStartBridgeRequest";
 
 export class UpstreamPatchContractError extends Error {
   constructor(contractName, message, options = {}) {
@@ -42,36 +38,7 @@ export class UpstreamPatchContractError extends Error {
   }
 }
 
-export const dynamicToolStartResponseContract = {
-  name: "dynamic-tool-start-response",
-  find: findDynamicToolStartResponsePatch,
-  assertBefore: assertDynamicToolStartResponseBefore,
-  apply: patchDynamicToolStartResponse,
-  assertAfter: assertDynamicToolStartResponseAfter
-};
-
-export const dynamicToolThreadStartBridgeContract = {
-  name: "dynamic-tool-thread-start-bridge",
-  find: findDynamicToolThreadStartBridgePatch,
-  assertBefore: assertDynamicToolThreadStartBridgeBefore,
-  apply: patchDynamicToolThreadStartBridge,
-  assertAfter: assertDynamicToolThreadStartBridgeAfter
-};
-
 export const upstreamPatchContracts = [
-  // Why: upstream can return runtime-built dynamic tools from the renderer
-  // just before thread creation. App-server rejects any function tool without
-  // inputSchema, so Linux normalizes the final Electron response boundary.
-  // Contract: the main bundle still resolves dynamic-tools-for-thread-start
-  // responses through handleDynamicToolsForThreadStartResponse.
-  dynamicToolStartResponseContract,
-  // Why: local desktop thread creation can bypass the renderer request client
-  // and enter Electron through host-command handlers. App-server still rejects
-  // malformed dynamic tool schemas there, so Linux normalizes the final bridge
-  // request before stdio transport. Contract: the main bundle still forwards
-  // mcp-request and thread-prewarm-start through handleClientRequest and
-  // handlePrewarmThreadStart.
-  dynamicToolThreadStartBridgeContract,
   // Why: upstream desktop only registers macOS open-in-editor targets; Linux
   // needs locally installed editors and terminal-backed Neovim. Contract:
   // upstream still exposes an open-target registry, runner, and preferred-target
@@ -125,22 +92,6 @@ export const owlFeatureBindingContract = {
   assertAfter: assertOwlFeatureBindingAfter
 };
 
-export const dynamicToolSchemaContract = {
-  name: "dynamic-tool-schema-contract",
-  find: findDynamicToolSchemaContractPatch,
-  assertBefore: assertDynamicToolSchemaContractBefore,
-  apply: patchDynamicToolSchemaContract,
-  assertAfter: assertDynamicToolSchemaContractAfter
-};
-
-export const dynamicToolThreadStartRequestContract = {
-  name: "dynamic-tool-thread-start-request",
-  find: findDynamicToolThreadStartRequestPatch,
-  assertBefore: assertDynamicToolThreadStartRequestBefore,
-  apply: patchDynamicToolThreadStartRequest,
-  assertAfter: assertDynamicToolThreadStartRequestAfter
-};
-
 export async function patchUpstreamApp(stageAppDir) {
   const buildDir = path.join(stageAppDir, ".vite", "build");
   const entries = await fs.readdir(buildDir);
@@ -156,35 +107,27 @@ export async function patchUpstreamApp(stageAppDir) {
 
   if (patched === source) {
     await patchOwlFeatureBindingChunks(buildDir, entries);
-    await patchDynamicToolSchemaContractChunks(stageAppDir);
-    await patchDynamicToolThreadStartRequestChunks(stageAppDir);
     return;
   }
 
   await fs.writeFile(mainBundlePath, patched);
   await patchOwlFeatureBindingChunks(buildDir, entries);
-  await patchDynamicToolSchemaContractChunks(stageAppDir);
-  await patchDynamicToolThreadStartRequestChunks(stageAppDir);
 }
 
 export function patchUpstreamMainSource(source) {
   return applyUpstreamPatchContracts(source, upstreamPatchContracts);
 }
 
-export function patchDynamicToolStartResponseSource(source) {
-  return applyUpstreamPatchContract(source, dynamicToolStartResponseContract);
-}
-
 export function patchLinuxOpenTargetsSource(source) {
-  return applyUpstreamPatchContract(source, upstreamPatchContracts[2]);
+  return applyUpstreamPatchContract(source, upstreamPatchContracts[0]);
 }
 
 export function patchDisableTransparencySource(source) {
-  return applyUpstreamPatchContracts(source, upstreamPatchContracts.slice(3, 5));
+  return applyUpstreamPatchContracts(source, upstreamPatchContracts.slice(1, 3));
 }
 
 export function patchLinuxWindowFocusableSource(source) {
-  return applyUpstreamPatchContract(source, upstreamPatchContracts[5]);
+  return applyUpstreamPatchContract(source, upstreamPatchContracts[3]);
 }
 
 export function patchLinuxOwlFeatureBindingSource(source) {
@@ -214,18 +157,6 @@ export function patchLinuxOwlFeatureBindingSource(source) {
   }
 }
 
-export function patchDynamicToolSchemaContractSource(source) {
-  return applyUpstreamPatchContract(source, dynamicToolSchemaContract);
-}
-
-export function patchDynamicToolThreadStartRequestSource(source) {
-  return applyUpstreamPatchContract(source, dynamicToolThreadStartRequestContract);
-}
-
-export function patchDynamicToolThreadStartBridgeSource(source) {
-  return applyUpstreamPatchContract(source, dynamicToolThreadStartBridgeContract);
-}
-
 export function hasUnguardedOwlFeatureBindingSource(source) {
   let index = -1;
 
@@ -247,30 +178,6 @@ export function hasUnguardedOwlFeatureBindingSource(source) {
   }
 
   return false;
-}
-
-export function hasUnguardedDynamicToolSchemaContractSource(source) {
-  const patch = findDynamicToolSchemaContractPatch(source);
-
-  return patch.status === "patch";
-}
-
-export function hasUnguardedDynamicToolStartResponseSource(source) {
-  const patch = findDynamicToolStartResponsePatch(source);
-
-  return patch.status === "patch";
-}
-
-export function hasUnguardedDynamicToolThreadStartRequestSource(source) {
-  const patch = findDynamicToolThreadStartRequestPatch(source);
-
-  return patch.status === "patch";
-}
-
-export function hasUnguardedDynamicToolThreadStartBridgeSource(source) {
-  const patch = findDynamicToolThreadStartBridgePatch(source);
-
-  return patch.status === "patch";
 }
 
 export function hasLinuxWindowFocusableContractSource(source) {
@@ -354,82 +261,6 @@ async function patchOwlFeatureBindingChunks(buildDir, entries) {
   }
 }
 
-async function patchDynamicToolSchemaContractChunks(stageAppDir) {
-  const assetsDir = path.join(stageAppDir, "webview", "assets");
-  let entries;
-
-  try {
-    entries = await fs.readdir(assetsDir);
-  } catch (error) {
-    if (error?.code === "ENOENT") {
-      throw new UpstreamPatchContractError(
-        dynamicToolSchemaContract.name,
-        `missing webview assets directory: ${assetsDir}`,
-        { cause: error }
-      );
-    }
-
-    throw error;
-  }
-
-  for (const entry of entries) {
-    if (!entry.endsWith(".js")) {
-      continue;
-    }
-
-    const bundlePath = path.join(assetsDir, entry);
-    const source = await fs.readFile(bundlePath, "utf8");
-
-    if (!source.includes("Tools provided by the Codex app.") || !source.includes("deferLoading")) {
-      continue;
-    }
-
-    const patched = patchDynamicToolSchemaContractSource(source);
-
-    if (patched !== source) {
-      await fs.writeFile(bundlePath, patched);
-    }
-  }
-}
-
-async function patchDynamicToolThreadStartRequestChunks(stageAppDir) {
-  const assetsDir = path.join(stageAppDir, "webview", "assets");
-  let entries;
-
-  try {
-    entries = await fs.readdir(assetsDir);
-  } catch (error) {
-    if (error?.code === "ENOENT") {
-      throw new UpstreamPatchContractError(
-        dynamicToolThreadStartRequestContract.name,
-        `missing webview assets directory: ${assetsDir}`,
-        { cause: error }
-      );
-    }
-
-    throw error;
-  }
-
-  for (const entry of entries) {
-    if (!entry.endsWith(".js")) {
-      continue;
-    }
-
-    const bundlePath = path.join(assetsDir, entry);
-    const source = await fs.readFile(bundlePath, "utf8");
-
-    if (!source.includes("mcp_request_enqueued") || !source.includes("thread/start")) {
-      continue;
-    }
-
-    const patched = patchDynamicToolThreadStartRequestSource(source);
-
-    if (patched !== source) {
-      await fs.writeFile(bundlePath, patched);
-    }
-  }
-}
-
 function findOwlFeatureBindingPatch(source) {
   const match = source.match(owlFeatureBindingRegex);
 
@@ -470,556 +301,6 @@ function findOwlFeatureBindingPatch(source) {
   }
 
   throw new Error("Unable to apply upstream patch; missing Owl feature binding helper");
-}
-
-function findDynamicToolStartResponsePatch(source) {
-  const patches = findDynamicToolStartResponsePatches(source);
-
-  if (patches.length > 0) {
-    return {
-      status: "patch",
-      patches
-    };
-  }
-
-  if (
-    source.includes(dynamicToolStartResponseMarker) &&
-    source.includes("handleDynamicToolsForThreadStartResponse")
-  ) {
-    return { status: "patched" };
-  }
-
-  if (source.includes("handleDynamicToolsForThreadStartResponse")) {
-    throw new Error("Unable to apply upstream patch; missing dynamic tool start response resolver");
-  }
-
-  throw new Error("Unable to apply upstream patch; missing dynamic tool start response resolver");
-}
-
-function findDynamicToolStartResponsePatches(source) {
-  const ast = parseJavaScript(source);
-  const patches = [];
-
-  walkAst(ast, node => {
-    if (
-      node.type !== "MethodDefinition" ||
-      propertyName(node.key) !== "handleDynamicToolsForThreadStartResponse"
-    ) {
-      return;
-    }
-
-    const responseParam = node.value?.params?.[1];
-
-    if (responseParam?.type !== "Identifier") {
-      return;
-    }
-
-    walkAst(node.value.body, child => {
-      if (
-        child.type !== "CallExpression" ||
-        !isMemberPropertyNamed(child.callee, "resolve") ||
-        child.arguments.length !== 1 ||
-        !isMemberExpressionNamed(child.arguments[0], responseParam.name, "dynamicTools")
-      ) {
-        return;
-      }
-
-      patches.push({
-        argumentStart: child.arguments[0].start,
-        argumentEnd: child.arguments[0].end
-      });
-    });
-  });
-
-  if (patches.length > 1) {
-    throw new Error("Unable to apply upstream patch; ambiguous dynamic tool start response resolver");
-  }
-
-  return patches;
-}
-
-function assertDynamicToolStartResponseBefore(source) {
-  const patch = findDynamicToolStartResponsePatch(source);
-
-  if (!patch || patch.status !== "patch") {
-    throw new Error("missing unguarded dynamic tool start response resolver");
-  }
-}
-
-function assertDynamicToolStartResponseAfter(source) {
-  if (!source.includes(dynamicToolStartResponseMarker)) {
-    throw new Error("missing dynamic tool start response normalizer");
-  }
-
-  if (!source.includes("handleDynamicToolsForThreadStartResponse")) {
-    throw new Error("missing dynamic tool start response handler");
-  }
-
-  if (hasUnguardedDynamicToolStartResponseSource(source)) {
-    throw new Error("unguarded dynamic tool start response resolver remains");
-  }
-}
-
-function patchDynamicToolStartResponse(source, patch = findDynamicToolStartResponsePatch(source)) {
-  if (patch?.status === "patched") {
-    return source;
-  }
-
-  const helper = source.includes(dynamicToolStartResponseMarker)
-    ? ""
-    : [
-        `function ${dynamicToolStartResponseMarker}(e){if(!Array.isArray(e))return[];return e.map(e=>{if(e?.type!==\`namespace\`||!Array.isArray(e.tools))return e;let t=e.tools.flatMap(e=>{if(e?.type!==\`function\`)return[e];if(e.inputSchema!=null)return[e];if(e.input_schema!=null)return[{...e,inputSchema:e.input_schema}];if(e.parameters!=null)return[{...e,inputSchema:e.parameters}];return[]});return{...e,tools:t}})}`
-      ].join("");
-  const replacements = patch.patches.map(target => {
-    const argumentSource = source.slice(target.argumentStart, target.argumentEnd);
-
-    return {
-      start: target.argumentStart,
-      end: target.argumentEnd,
-      replacement: `${dynamicToolStartResponseMarker}(${argumentSource})`
-    };
-  });
-
-  replacements.sort((left, right) => right.start - left.start);
-
-  let patched = source;
-  for (const replacement of replacements) {
-    patched = `${patched.slice(0, replacement.start)}${replacement.replacement}${patched.slice(replacement.end)}`;
-  }
-
-  return helper ? `${patched}\n${helper}` : patched;
-}
-
-function findDynamicToolThreadStartBridgePatch(source) {
-  const patches = findDynamicToolThreadStartBridgePatches(source);
-
-  if (patches.length > 0) {
-    return {
-      status: "patch",
-      patches
-    };
-  }
-
-  if (
-    source.includes(dynamicToolThreadStartBridgeMarker) &&
-    source.includes("handleClientRequest") &&
-    source.includes("handlePrewarmThreadStart")
-  ) {
-    return { status: "patched" };
-  }
-
-  if (source.includes("handleClientRequest") || source.includes("handlePrewarmThreadStart")) {
-    throw new Error("Unable to apply upstream patch; missing thread/start bridge request forwarding");
-  }
-
-  throw new Error("Unable to apply upstream patch; missing thread/start bridge request forwarding");
-}
-
-function findDynamicToolThreadStartBridgePatches(source) {
-  const ast = parseJavaScript(source);
-  const patches = [];
-
-  walkAst(ast, node => {
-    if (
-      node.type !== "CallExpression" ||
-      (
-        !isMemberPropertyNamed(node.callee, "handleClientRequest") &&
-        !isMemberPropertyNamed(node.callee, "handlePrewarmThreadStart")
-      )
-    ) {
-      return;
-    }
-
-    const requestArg = node.arguments[1];
-
-    if (!requestArg || isCallToIdentifier(requestArg, dynamicToolThreadStartBridgeMarker)) {
-      return;
-    }
-
-    patches.push({
-      requestStart: requestArg.start,
-      requestEnd: requestArg.end
-    });
-  });
-
-  return patches;
-}
-
-function assertDynamicToolThreadStartBridgeBefore(source) {
-  const patch = findDynamicToolThreadStartBridgePatch(source);
-
-  if (!patch || patch.status !== "patch") {
-    throw new Error("missing unguarded thread/start bridge request");
-  }
-}
-
-function assertDynamicToolThreadStartBridgeAfter(source) {
-  if (!source.includes(dynamicToolThreadStartBridgeMarker)) {
-    throw new Error("missing thread/start bridge request normalizer");
-  }
-
-  if (!source.includes("handleClientRequest") || !source.includes("handlePrewarmThreadStart")) {
-    throw new Error("missing app-server bridge request forwarding");
-  }
-
-  if (hasUnguardedDynamicToolThreadStartBridgeSource(source)) {
-    throw new Error("unguarded thread/start bridge request forwarding remains");
-  }
-}
-
-function patchDynamicToolThreadStartBridge(source, patch = findDynamicToolThreadStartBridgePatch(source)) {
-  if (patch?.status === "patched") {
-    return source;
-  }
-
-  const helper = source.includes(dynamicToolThreadStartBridgeMarker)
-    ? ""
-    : [
-        `function ${dynamicToolThreadStartBridgeMarker}(e){if(e?.method!==\`thread/start\`||e.params==null)return e;let t=__codexLinuxNormalizeThreadStartBridgeValue(e.params);return{...e,params:{...t,...Array.isArray(t.dynamicTools)?{dynamicTools:t.dynamicTools.flatMap(e=>__codexLinuxNormalizeThreadStartBridgeDynamicTool(e))}:{}}}}`,
-        `function __codexLinuxNormalizeThreadStartBridgeValue(e){if(Array.isArray(e))return e.map(__codexLinuxNormalizeThreadStartBridgeValue);if(e==null||typeof e!==\`object\`)return e;let t={...e};for(let n of Object.keys(t))t[n]=__codexLinuxNormalizeThreadStartBridgeValue(t[n]);if(t.inputSchema==null){if(t.input_schema!=null)t.inputSchema=t.input_schema;else if(t.parameters!=null)t.inputSchema=t.parameters;else if(t.type===\`function\`)t.inputSchema={type:\`object\`,properties:{},additionalProperties:!1}}return t}`,
-        `function __codexLinuxNormalizeThreadStartBridgeDynamicTool(e,t=null){e=__codexLinuxNormalizeThreadStartBridgeValue(e);if(e==null||typeof e!==\`object\`)return[];if(e.type===\`namespace\`&&Array.isArray(e.tools)){let n=typeof e.name===\`string\`?e.name:t;return e.tools.flatMap(e=>__codexLinuxNormalizeThreadStartBridgeDynamicTool(e,n))}let n=t==null?e:{...e,namespace:e.namespace??t};if(n.type==null&&typeof n.name===\`string\`)return[{...n,type:\`function\`,inputSchema:n.inputSchema??{type:\`object\`,properties:{},additionalProperties:!1}}];return n.type===\`function\`?[n]:[]}`
-      ].join("");
-  const replacements = patch.patches.map(target => {
-    const requestSource = source.slice(target.requestStart, target.requestEnd);
-
-    return {
-      start: target.requestStart,
-      end: target.requestEnd,
-      replacement: `${dynamicToolThreadStartBridgeMarker}(${requestSource})`
-    };
-  });
-
-  replacements.sort((left, right) => right.start - left.start);
-
-  let patched = source;
-  for (const replacement of replacements) {
-    patched = `${patched.slice(0, replacement.start)}${replacement.replacement}${patched.slice(replacement.end)}`;
-  }
-
-  return helper ? `${patched}\n${helper}` : patched;
-}
-
-function findDynamicToolThreadStartRequestPatch(source) {
-  const patches = findDynamicToolThreadStartRequestPatches(source);
-
-  if (patches.length > 0) {
-    return {
-      status: "patch",
-      patches
-    };
-  }
-
-  if (
-    source.includes(dynamicToolThreadStartRequestMarker) &&
-    source.includes("mcp_request_enqueued") &&
-    source.includes("thread/start")
-  ) {
-    return { status: "patched" };
-  }
-
-  if (source.includes("mcp_request_enqueued") && source.includes("thread/start")) {
-    throw new Error("Unable to apply upstream patch; missing thread/start request params");
-  }
-
-  throw new Error("Unable to apply upstream patch; missing thread/start request params");
-}
-
-function findDynamicToolThreadStartRequestPatches(source) {
-  const ast = parseJavaScript(source);
-  const patches = [];
-
-  walkAst(ast, node => {
-    if (
-      node.type !== "MethodDefinition" ||
-      propertyName(node.key) !== "createRequest"
-    ) {
-      return;
-    }
-
-    const methodParam = node.value?.params?.[0];
-    const paramsParam = node.value?.params?.[1];
-
-    if (methodParam?.type !== "Identifier" || paramsParam?.type !== "Identifier") {
-      return;
-    }
-
-    walkAst(node.value.body, child => {
-      if (child.type !== "ObjectExpression") {
-        return;
-      }
-
-      const requestProperty = child.properties.find(property =>
-        property.type === "Property" &&
-        propertyName(property.key) === "request" &&
-        property.value?.type === "ObjectExpression"
-      );
-      const promiseProperty = child.properties.find(property =>
-        property.type === "Property" &&
-        propertyName(property.key) === "promise"
-      );
-
-      if (!requestProperty || !promiseProperty) {
-        return;
-      }
-
-      const requestObject = requestProperty.value;
-      const methodProperty = requestObject.properties.find(property =>
-        property.type === "Property" &&
-        propertyName(property.key) === "method" &&
-        isIdentifierNamed(property.value, methodParam.name)
-      );
-      const paramsProperty = requestObject.properties.find(property =>
-        property.type === "Property" &&
-        propertyName(property.key) === "params" &&
-        isIdentifierNamed(property.value, paramsParam.name)
-      );
-
-      if (!methodProperty || !paramsProperty) {
-        return;
-      }
-
-      patches.push({
-        methodParamName: methodParam.name,
-        paramsParamName: paramsParam.name,
-        paramsStart: paramsProperty.value.start,
-        paramsEnd: paramsProperty.value.end
-      });
-    });
-  });
-
-  if (patches.length > 1) {
-    throw new Error("Unable to apply upstream patch; ambiguous thread/start request params");
-  }
-
-  return patches;
-}
-
-function assertDynamicToolThreadStartRequestBefore(source) {
-  const patch = findDynamicToolThreadStartRequestPatch(source);
-
-  if (!patch || patch.status !== "patch") {
-    throw new Error("missing unguarded thread/start request params");
-  }
-}
-
-function assertDynamicToolThreadStartRequestAfter(source) {
-  if (!source.includes(dynamicToolThreadStartRequestMarker)) {
-    throw new Error("missing thread/start request params normalizer");
-  }
-
-  if (!source.includes("mcp_request_enqueued") || !source.includes("thread/start")) {
-    throw new Error("missing app-server request client");
-  }
-
-  if (hasUnguardedDynamicToolThreadStartRequestSource(source)) {
-    throw new Error("unguarded thread/start request params remain");
-  }
-}
-
-function patchDynamicToolThreadStartRequest(source, patch = findDynamicToolThreadStartRequestPatch(source)) {
-  if (patch?.status === "patched") {
-    return source;
-  }
-
-  const helper = source.includes(dynamicToolThreadStartRequestMarker)
-    ? ""
-    : [
-        `function ${dynamicToolThreadStartRequestMarker}(e){if(e==null||!Array.isArray(e.dynamicTools))return e;return{...e,dynamicTools:e.dynamicTools.flatMap(e=>__codexLinuxNormalizeThreadStartRequestDynamicTool(e))}}function __codexLinuxNormalizeThreadStartRequestDynamicTool(e,t=null){if(e==null||typeof e!==\`object\`)return[];if(e.type===\`namespace\`&&Array.isArray(e.tools)){let n=typeof e.name===\`string\`?e.name:t;return e.tools.flatMap(e=>__codexLinuxNormalizeThreadStartRequestDynamicTool(e,n))}let n=t==null?e:{...e,namespace:e.namespace??t};if(n.type==null&&typeof n.name===\`string\`)return[{...n,type:\`function\`,inputSchema:n.inputSchema??n.input_schema??n.parameters??{type:\`object\`,properties:{},additionalProperties:!1}}];if(n.type!==\`function\`)return[];if(n.inputSchema!=null)return[n];if(n.input_schema!=null)return[{...n,inputSchema:n.input_schema}];if(n.parameters!=null)return[{...n,inputSchema:n.parameters}];return[{...n,inputSchema:{type:\`object\`,properties:{},additionalProperties:!1}}]}`
-      ].join("");
-  const replacements = patch.patches.map(target => {
-    const paramsSource = source.slice(target.paramsStart, target.paramsEnd);
-
-    return {
-      start: target.paramsStart,
-      end: target.paramsEnd,
-      replacement: `${target.methodParamName}===\`thread/start\`?${dynamicToolThreadStartRequestMarker}(${paramsSource}):${paramsSource}`
-    };
-  });
-
-  replacements.sort((left, right) => right.start - left.start);
-
-  let patched = source;
-  for (const replacement of replacements) {
-    patched = `${patched.slice(0, replacement.start)}${replacement.replacement}${patched.slice(replacement.end)}`;
-  }
-
-  return helper ? `${patched}\n${helper}` : patched;
-}
-
-function findDynamicToolSchemaContractPatch(source) {
-  const patches = findDynamicToolSchemaContractPatches(source);
-
-  if (patches.length > 0) {
-    return {
-      status: "patch",
-      patches
-    };
-  }
-
-  if (
-    source.includes(dynamicToolSchemaContractMarker) &&
-    source.includes("Tools provided by the Codex app.")
-  ) {
-    return { status: "patched" };
-  }
-
-  if (source.includes("Tools provided by the Codex app.") && source.includes("deferLoading")) {
-    throw new Error("Unable to apply upstream patch; missing dynamic tool schema mapper");
-  }
-
-  throw new Error("Unable to apply upstream patch; missing dynamic tool schema mapper");
-}
-
-function findDynamicToolSchemaContractPatches(source) {
-  const ast = parseJavaScript(source);
-  const patches = [];
-
-  walkAst(ast, node => {
-    if (node.type !== "CallExpression" || !isMemberPropertyNamed(node.callee, "map")) {
-      return;
-    }
-
-    const callback = node.arguments[0];
-    const callbackParam = callback?.params?.[0];
-    const body = callback?.body;
-
-    if (
-      callback?.type !== "ArrowFunctionExpression" ||
-      callbackParam?.type !== "Identifier" ||
-      body?.type !== "ObjectExpression" ||
-      !isDynamicToolFunctionObject(body, callbackParam.name)
-    ) {
-      return;
-    }
-
-    const context = source.slice(Math.max(0, node.start - 1500), Math.min(source.length, node.end + 1500));
-
-    if (!context.includes("Tools provided by the Codex app.") || !context.includes("deferLoading")) {
-      return;
-    }
-
-    patches.push({
-      callEnd: node.end,
-      objectStart: body.start,
-      objectEnd: body.end
-    });
-  });
-
-  if (patches.length > 1) {
-    throw new Error("Unable to apply upstream patch; ambiguous dynamic tool schema mapper");
-  }
-
-  return patches;
-}
-
-function isDynamicToolFunctionObject(object, toolVarName) {
-  let hasFunctionType = false;
-  let spreadsTool = false;
-  let hasDeferLoading = false;
-
-  for (const property of object.properties) {
-    if (property.type === "SpreadElement") {
-      if (isIdentifierNamed(property.argument, toolVarName)) {
-        spreadsTool = true;
-      }
-
-      const sourceName = property.argument?.type === "ConditionalExpression"
-        ? objectPropertyNames(property.argument.consequent).concat(objectPropertyNames(property.argument.alternate))
-        : [];
-
-      if (sourceName.includes("deferLoading")) {
-        hasDeferLoading = true;
-      }
-
-      continue;
-    }
-
-    if (property.type !== "Property") {
-      continue;
-    }
-
-    const key = propertyName(property.key);
-
-    if (key === "type" && isStringLiteral(property.value, "function")) {
-      hasFunctionType = true;
-    }
-
-    if (key === "deferLoading") {
-      hasDeferLoading = true;
-    }
-  }
-
-  return hasFunctionType && spreadsTool && hasDeferLoading;
-}
-
-function objectPropertyNames(node) {
-  if (node?.type !== "ObjectExpression") {
-    return [];
-  }
-
-  return node.properties
-    .filter(property => property.type === "Property")
-    .map(property => propertyName(property.key))
-    .filter(Boolean);
-}
-
-function assertDynamicToolSchemaContractBefore(source) {
-  const patch = findDynamicToolSchemaContractPatch(source);
-
-  if (!patch || patch.status !== "patch") {
-    throw new Error("missing unguarded dynamic tool schema mapper");
-  }
-}
-
-function assertDynamicToolSchemaContractAfter(source) {
-  if (!source.includes(dynamicToolSchemaContractMarker)) {
-    throw new Error("missing dynamic tool schema contract helper");
-  }
-
-  if (!source.includes("Tools provided by the Codex app.")) {
-    throw new Error("missing dynamic tool namespace builder");
-  }
-
-  if (hasUnguardedDynamicToolSchemaContractSource(source)) {
-    throw new Error("unguarded dynamic tool schema mapper remains");
-  }
-}
-
-function patchDynamicToolSchemaContract(source, patch = findDynamicToolSchemaContractPatch(source)) {
-  if (patch?.status === "patched") {
-    return source;
-  }
-
-  const helper = source.includes(dynamicToolSchemaContractMarker)
-    ? ""
-    : [
-        `function ${dynamicToolSchemaContractMarker}(e){if(e==null||e.type!==\`function\`)return e;if(e.inputSchema!=null)return e;if(e.input_schema!=null)return{...e,inputSchema:e.input_schema};if(e.parameters!=null)return{...e,inputSchema:e.parameters};return null}`
-      ].join("");
-  const replacements = [];
-
-  for (const target of patch.patches) {
-    const objectSource = source.slice(target.objectStart, target.objectEnd);
-
-    replacements.push({
-      start: target.objectStart,
-      end: target.objectEnd,
-      replacement: `${dynamicToolSchemaContractMarker}(${objectSource})`
-    });
-    replacements.push({
-      start: target.callEnd,
-      end: target.callEnd,
-      replacement: ".filter(Boolean)"
-    });
-  }
-
-  replacements.sort((left, right) => right.start - left.start);
-
-  let patched = source;
-  for (const replacement of replacements) {
-    patched = `${patched.slice(0, replacement.start)}${replacement.replacement}${patched.slice(replacement.end)}`;
-  }
-
-  return helper ? `${patched}\n${helper}` : patched;
 }
 
 function assertOwlFeatureBindingBefore(source) {
@@ -1630,22 +911,6 @@ function isMemberPropertyNamed(node, name) {
     node?.type === "MemberExpression" &&
     !node.computed &&
     propertyName(node.property) === name
-  );
-}
-
-function isMemberExpressionNamed(node, objectName, property) {
-  return (
-    node?.type === "MemberExpression" &&
-    !node.computed &&
-    isIdentifierNamed(node.object, objectName) &&
-    propertyName(node.property) === property
-  );
-}
-
-function isCallToIdentifier(node, name) {
-  return (
-    node?.type === "CallExpression" &&
-    isIdentifierNamed(node.callee, name)
   );
 }
 

--- a/scripts/smoke-artifacts.mjs
+++ b/scripts/smoke-artifacts.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import net from "node:net";
+import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { spawn, spawnSync } from "node:child_process";
@@ -8,10 +9,6 @@ import * as asar from "@electron/asar";
 import { channelPaths, getChannel, parseArgs, projectRoot } from "./lib/config.mjs";
 import {
   hasLinuxWindowFocusableContractSource,
-  hasUnguardedDynamicToolSchemaContractSource,
-  hasUnguardedDynamicToolStartResponseSource,
-  hasUnguardedDynamicToolThreadStartBridgeSource,
-  hasUnguardedDynamicToolThreadStartRequestSource,
   hasUnguardedLinuxWindowFocusableSource,
   hasUnguardedOwlFeatureBindingSource
 } from "./lib/upstream-patches.mjs";
@@ -67,6 +64,9 @@ export async function smokeLinuxArtifacts({
   await runCheck(summary, "bundled-codex-launcher", () =>
     assertBundledCodexLauncher(linuxDir, executablePath, resourcesDir)
   );
+  await runCheck(summary, "bundled-codex-dynamic-tools", () =>
+    smokeBundledCodexDynamicTools(resourcesDir)
+  );
   await runCheck(summary, "node_repl", () =>
     smokeNodeRepl(path.join(resourcesDir, "node_repl"))
   );
@@ -78,18 +78,6 @@ export async function smokeLinuxArtifacts({
   );
   await runCheck(summary, "linux-window-focusable-contract", () =>
     assertLinuxWindowFocusableContract(resourcesDir)
-  );
-  await runCheck(summary, "dynamic-tool-schema-contract", () =>
-    assertDynamicToolSchemaContract(resourcesDir)
-  );
-  await runCheck(summary, "dynamic-tool-start-response-contract", () =>
-    assertDynamicToolStartResponseContract(resourcesDir)
-  );
-  await runCheck(summary, "dynamic-tool-thread-start-bridge-contract", () =>
-    assertDynamicToolThreadStartBridgeContract(resourcesDir)
-  );
-  await runCheck(summary, "dynamic-tool-thread-start-request-contract", () =>
-    assertDynamicToolThreadStartRequestContract(resourcesDir)
   );
 
   if (packageDir) {
@@ -279,6 +267,197 @@ export function evaluateBundledCodexLauncherSource(source) {
   }
 }
 
+async function smokeBundledCodexDynamicTools(resourcesDir) {
+  const executablePath = path.resolve(resourcesDir, "codex");
+  await accessFile(executablePath, "bundled Codex CLI");
+  const codexHome = await fs.mkdtemp(path.join(os.tmpdir(), "codex-app-linux-dynamic-tools-"));
+  const child = spawn(executablePath, ["app-server", "--stdio"], {
+    cwd: codexHome,
+    env: {
+      ...process.env,
+      CODEX_HOME: codexHome
+    },
+    stdio: ["pipe", "pipe", "pipe"]
+  });
+  let stderr = "";
+
+  child.stderr.on("data", chunk => {
+    stderr += chunk.toString();
+  });
+
+  try {
+    return await new Promise((resolve, reject) => {
+      let buffer = "";
+      let canonicalThreadId;
+      let legacyThreadId;
+      let settled = false;
+      const timer = setTimeout(() => {
+        finish(reject, new Error(`bundled Codex dynamic-tool smoke timed out: ${stderr.slice(-1000)}`));
+      }, 20_000);
+      const finish = (callback, value) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        clearTimeout(timer);
+        callback(value);
+      };
+      const send = message => {
+        child.stdin.write(`${JSON.stringify(message)}\n`);
+      };
+      const threadStartParams = dynamicTools => ({
+        cwd: codexHome,
+        ephemeral: true,
+        dynamicTools
+      });
+
+      child.once("error", error => finish(reject, error));
+      child.once("exit", (code, signal) => {
+        finish(
+          reject,
+          new Error(`bundled Codex app-server exited before dynamic-tool smoke completed: exit=${code} signal=${signal} stderr=${stderr.slice(-1000)}`)
+        );
+      });
+      child.stdout.on("data", chunk => {
+        buffer += chunk.toString();
+
+        while (buffer.includes("\n")) {
+          const newlineIndex = buffer.indexOf("\n");
+          const line = buffer.slice(0, newlineIndex).trim();
+          buffer = buffer.slice(newlineIndex + 1);
+
+          if (!line) {
+            continue;
+          }
+
+          let message;
+
+          try {
+            message = JSON.parse(line);
+          } catch (error) {
+            finish(reject, new Error(`bundled Codex app-server emitted invalid JSON: ${line.slice(0, 500)}`, {
+              cause: error
+            }));
+            return;
+          }
+
+          if (message.id === 1) {
+            if (message.error) {
+              finish(reject, new Error(`bundled Codex initialize failed: ${message.error.message}`));
+              return;
+            }
+
+            send({ method: "initialized", params: {} });
+            send({
+              id: 2,
+              method: "thread/start",
+              params: threadStartParams([{
+                type: "namespace",
+                name: "codex_app",
+                description: "Canonical smoke namespace",
+                tools: [{
+                  type: "function",
+                  name: "canonical_smoke_tool",
+                  description: "Canonical smoke tool",
+                  inputSchema: {
+                    type: "object",
+                    properties: {},
+                    additionalProperties: false
+                  }
+                }]
+              }])
+            });
+            continue;
+          }
+
+          if (message.id === 2) {
+            if (message.error || !message.result?.thread?.id) {
+              finish(reject, new Error(`bundled Codex rejected canonical dynamic tools: ${message.error?.message || "missing thread result"}`));
+              return;
+            }
+
+            canonicalThreadId = message.result.thread.id;
+            send({
+              id: 3,
+              method: "thread/start",
+              params: threadStartParams([{
+                namespace: "legacy_app",
+                name: "legacy_smoke_tool",
+                description: "Legacy smoke tool",
+                inputSchema: {
+                  type: "object",
+                  properties: {},
+                  additionalProperties: false
+                },
+                exposeToContext: true
+              }])
+            });
+            continue;
+          }
+
+          if (message.id === 3) {
+            if (message.error || !message.result?.thread?.id) {
+              finish(reject, new Error(`bundled Codex rejected legacy dynamic tools: ${message.error?.message || "missing thread result"}`));
+              return;
+            }
+
+            legacyThreadId = message.result.thread.id;
+            send({
+              id: 4,
+              method: "thread/start",
+              params: threadStartParams([{
+                type: "function",
+                namespace: "codex_app",
+                name: "hybrid_smoke_tool",
+                description: "Invalid hybrid smoke tool",
+                inputSchema: {
+                  type: "object",
+                  properties: {},
+                  additionalProperties: false
+                }
+              }])
+            });
+            continue;
+          }
+
+          if (message.id === 4) {
+            if (!message.error?.message?.includes("dynamic tools must use either canonical or legacy format consistently")) {
+              finish(reject, new Error(`bundled Codex accepted an invalid hybrid dynamic-tool request: ${JSON.stringify(message)}`));
+              return;
+            }
+
+            finish(resolve, {
+              canonicalThreadId,
+              legacyThreadId,
+              hybridRejected: true
+            });
+            return;
+          }
+        }
+      });
+
+      send({
+        id: 1,
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "codex-app-linux-smoke",
+            version: "1.0.0"
+          },
+          capabilities: {
+            experimentalApi: true,
+            requestAttestation: false
+          }
+        }
+      });
+    });
+  } finally {
+    await terminateProcess(child);
+    await fs.rm(codexHome, { recursive: true, force: true });
+  }
+}
+
 async function smokeDesktopBinary(executablePath, resourcesDir) {
   const result = await runCommand(executablePath, ["--no-sandbox"], {
     capture: true,
@@ -369,25 +548,6 @@ async function assertOwlRuntimeContract(resourcesDir) {
   };
 }
 
-async function assertDynamicToolSchemaContract(resourcesDir) {
-  const appAsarPath = path.join(resourcesDir, "app.asar");
-  const unsafeSources = await findUnguardedDynamicToolSchemaSources(appAsarPath);
-
-  if (unsafeSources.unsafe.length > 0) {
-    throw new Error(
-      `Thread-start dynamic tools must normalize inputSchema before startThread; ${unsafeSources.unsafe.slice(0, 5).join(", ")} still exposes an unguarded dynamic tool mapper and can fail with "Invalid request: missing field inputSchema"`
-    );
-  }
-
-  if (unsafeSources.checked === 0) {
-    throw new Error("Unable to find thread-start dynamic tool schema contract in app.asar");
-  }
-
-  return {
-    checked: unsafeSources.checked
-  };
-}
-
 async function assertLinuxWindowFocusableContract(resourcesDir) {
   const appAsarPath = path.join(resourcesDir, "app.asar");
   const unsafeSources = await findLinuxWindowFocusableContractSources(appAsarPath);
@@ -400,63 +560,6 @@ async function assertLinuxWindowFocusableContract(resourcesDir) {
 
   if (unsafeSources.checked === 0) {
     throw new Error("Unable to find Linux BrowserWindow focusable contract in app.asar");
-  }
-
-  return {
-    checked: unsafeSources.checked
-  };
-}
-
-async function assertDynamicToolStartResponseContract(resourcesDir) {
-  const appAsarPath = path.join(resourcesDir, "app.asar");
-  const unsafeSources = await findUnguardedDynamicToolStartResponseSources(appAsarPath);
-
-  if (unsafeSources.unsafe.length > 0) {
-    throw new Error(
-      `Desktop thread-start dynamic tools must normalize inputSchema before app-server thread/start; ${unsafeSources.unsafe.slice(0, 5).join(", ")} still resolves raw dynamicTools and can fail with "Invalid request: missing field inputSchema"`
-    );
-  }
-
-  if (unsafeSources.checked === 0) {
-    throw new Error("Unable to find desktop dynamic tool start response contract in app.asar");
-  }
-
-  return {
-    checked: unsafeSources.checked
-  };
-}
-
-async function assertDynamicToolThreadStartBridgeContract(resourcesDir) {
-  const appAsarPath = path.join(resourcesDir, "app.asar");
-  const unsafeSources = await findUnguardedDynamicToolThreadStartBridgeSources(appAsarPath);
-
-  if (unsafeSources.unsafe.length > 0) {
-    throw new Error(
-      `Electron bridge thread/start requests must normalize dynamicTools inputSchema before app-server; ${unsafeSources.unsafe.slice(0, 5).join(", ")} still forwards raw params and can fail with "Invalid request: missing field inputSchema"`
-    );
-  }
-
-  if (unsafeSources.checked === 0) {
-    throw new Error("Unable to find Electron bridge thread/start request contract in app.asar");
-  }
-
-  return {
-    checked: unsafeSources.checked
-  };
-}
-
-async function assertDynamicToolThreadStartRequestContract(resourcesDir) {
-  const appAsarPath = path.join(resourcesDir, "app.asar");
-  const unsafeSources = await findUnguardedDynamicToolThreadStartRequestSources(appAsarPath);
-
-  if (unsafeSources.unsafe.length > 0) {
-    throw new Error(
-      `Renderer thread/start requests must normalize dynamicTools inputSchema at request creation; ${unsafeSources.unsafe.slice(0, 5).join(", ")} still forwards raw params and can fail with "Invalid request: missing field inputSchema"`
-    );
-  }
-
-  if (unsafeSources.checked === 0) {
-    throw new Error("Unable to find renderer thread/start request params contract in app.asar");
   }
 
   return {
@@ -516,45 +619,6 @@ export function evaluateLinuxWindowFocusableContractSources(sources) {
   };
 }
 
-async function findUnguardedDynamicToolThreadStartBridgeSources(appAsarPath) {
-  const files = await asar.listPackage(appAsarPath);
-  const unsafe = [];
-  let checked = 0;
-
-  for (const file of files) {
-    if (!/\.(?:js|mjs|cjs)$/i.test(file)) {
-      continue;
-    }
-
-    let source;
-
-    try {
-      source = asar.extractFile(appAsarPath, file.replace(/^\//, "")).toString("utf8");
-    } catch {
-      continue;
-    }
-
-    if (
-      !source.includes("app_server.bridge_received") ||
-      !source.includes("handleClientRequest") ||
-      !source.includes("handlePrewarmThreadStart")
-    ) {
-      continue;
-    }
-
-    checked++;
-
-    if (hasUnguardedDynamicToolThreadStartBridgeSource(source)) {
-      unsafe.push(file.replace(/^\//, ""));
-    }
-  }
-
-  return {
-    checked,
-    unsafe
-  };
-}
-
 async function findUnguardedOwlBindingSources(appAsarPath) {
   const files = await asar.listPackage(appAsarPath);
   const unsafe = [];
@@ -578,114 +642,6 @@ async function findUnguardedOwlBindingSources(appAsarPath) {
   }
 
   return unsafe;
-}
-
-async function findUnguardedDynamicToolStartResponseSources(appAsarPath) {
-  const files = await asar.listPackage(appAsarPath);
-  const unsafe = [];
-  let checked = 0;
-
-  for (const file of files) {
-    if (!/\.(?:js|mjs|cjs)$/i.test(file)) {
-      continue;
-    }
-
-    let source;
-
-    try {
-      source = asar.extractFile(appAsarPath, file.replace(/^\//, "")).toString("utf8");
-    } catch {
-      continue;
-    }
-
-    if (
-      !source.includes("handleDynamicToolsForThreadStartResponse") ||
-      !source.includes("pendingDynamicToolsForThreadStartRequests")
-    ) {
-      continue;
-    }
-
-    checked++;
-
-    if (hasUnguardedDynamicToolStartResponseSource(source)) {
-      unsafe.push(file.replace(/^\//, ""));
-    }
-  }
-
-  return {
-    checked,
-    unsafe
-  };
-}
-
-async function findUnguardedDynamicToolSchemaSources(appAsarPath) {
-  const files = await asar.listPackage(appAsarPath);
-  const unsafe = [];
-  let checked = 0;
-
-  for (const file of files) {
-    if (!/\.(?:js|mjs|cjs)$/i.test(file)) {
-      continue;
-    }
-
-    let source;
-
-    try {
-      source = asar.extractFile(appAsarPath, file.replace(/^\//, "")).toString("utf8");
-    } catch {
-      continue;
-    }
-
-    if (!source.includes("Tools provided by the Codex app.") || !source.includes("deferLoading")) {
-      continue;
-    }
-
-    checked++;
-
-    if (hasUnguardedDynamicToolSchemaContractSource(source)) {
-      unsafe.push(file.replace(/^\//, ""));
-    }
-  }
-
-  return {
-    checked,
-    unsafe
-  };
-}
-
-async function findUnguardedDynamicToolThreadStartRequestSources(appAsarPath) {
-  const files = await asar.listPackage(appAsarPath);
-  const unsafe = [];
-  let checked = 0;
-
-  for (const file of files) {
-    if (!/\.(?:js|mjs|cjs)$/i.test(file)) {
-      continue;
-    }
-
-    let source;
-
-    try {
-      source = asar.extractFile(appAsarPath, file.replace(/^\//, "")).toString("utf8");
-    } catch {
-      continue;
-    }
-
-    if (!source.includes("mcp_request_enqueued") || !source.includes("thread/start")) {
-      continue;
-    }
-
-    checked++;
-
-    if (hasUnguardedDynamicToolThreadStartRequestSource(source)) {
-      unsafe.push(file.replace(/^\//, ""));
-    }
-  }
-
-  return {
-    checked,
-    unsafe
-  };
 }
 
 async function smokeWebShell({ linuxDir, packageDir, port }) {

--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -91,6 +91,10 @@ test("stagePackagedResources preserves Linux-safe upstream resources", async () 
     "mach-o-arm64"
   );
   await fs.writeFile(path.join(resourcesDir, "codex"), "darwin-codex");
+  await fs.writeFile(
+    path.join(resourcesDir, "codex-code-mode-host"),
+    "darwin-code-mode-host"
+  );
   await fs.mkdir(path.join(resourcesDir, "cua_node", "bin"), { recursive: true });
   await fs.writeFile(path.join(resourcesDir, "cua_node", "bin", "node_repl"), "darwin-node-repl");
   await fs.writeFile(path.join(resourcesDir, "node"), "darwin-node");
@@ -104,6 +108,7 @@ test("stagePackagedResources preserves Linux-safe upstream resources", async () 
   await assert.rejects(fs.access(path.join(targetDir, "app.asar")));
   await assert.rejects(fs.access(path.join(targetDir, "app.asar.unpacked")));
   await assert.rejects(fs.access(path.join(targetDir, "codex")));
+  await assert.rejects(fs.access(path.join(targetDir, "codex-code-mode-host")));
   await assert.rejects(fs.access(path.join(targetDir, "cua_node")));
   await assert.rejects(fs.access(path.join(targetDir, "node")));
   await assert.rejects(fs.access(path.join(targetDir, "rg")));

--- a/test/upstream-patches.test.mjs
+++ b/test/upstream-patches.test.mjs
@@ -4,26 +4,14 @@ import fs from "node:fs/promises";
 import vm from "node:vm";
 
 import {
-  hasUnguardedDynamicToolSchemaContractSource,
-  hasUnguardedDynamicToolStartResponseSource,
-  hasUnguardedDynamicToolThreadStartBridgeSource,
-  hasUnguardedDynamicToolThreadStartRequestSource,
   hasLinuxWindowFocusableContractSource,
   hasUnguardedLinuxWindowFocusableSource,
   hasUnguardedOwlFeatureBindingSource,
-  patchDynamicToolSchemaContractSource,
-  patchDynamicToolStartResponseSource,
-  patchDynamicToolThreadStartBridgeSource,
-  patchDynamicToolThreadStartRequestSource,
   patchDisableTransparencySource,
   patchLinuxOwlFeatureBindingSource,
   patchLinuxWindowFocusableSource,
   patchLinuxOpenTargetsSource,
-  dynamicToolThreadStartBridgeContract,
-  dynamicToolStartResponseContract,
-  upstreamPatchContracts,
-  dynamicToolSchemaContract,
-  dynamicToolThreadStartRequestContract
+  upstreamPatchContracts
 } from "../scripts/lib/upstream-patches.mjs";
 
 const openTargetResolverSource =
@@ -181,34 +169,12 @@ test("upstream patch contracts declare required contract surface", () => {
   assert.deepEqual(
     upstreamPatchContracts.map(contract => contract.name),
     [
-      "dynamic-tool-start-response",
-      "dynamic-tool-thread-start-bridge",
       "open-target-dispatcher",
       "linux-window-background",
       "linux-window-transparency",
       "linux-window-focusable-default"
     ]
   );
-  assert.deepEqual(
-    Object.keys(dynamicToolStartResponseContract).sort(),
-    ["apply", "assertAfter", "assertBefore", "find", "name"]
-  );
-  assert.equal(dynamicToolStartResponseContract.name, "dynamic-tool-start-response");
-  assert.deepEqual(
-    Object.keys(dynamicToolThreadStartBridgeContract).sort(),
-    ["apply", "assertAfter", "assertBefore", "find", "name"]
-  );
-  assert.equal(dynamicToolThreadStartBridgeContract.name, "dynamic-tool-thread-start-bridge");
-  assert.deepEqual(
-    Object.keys(dynamicToolSchemaContract).sort(),
-    ["apply", "assertAfter", "assertBefore", "find", "name"]
-  );
-  assert.equal(dynamicToolSchemaContract.name, "dynamic-tool-schema-contract");
-  assert.deepEqual(
-    Object.keys(dynamicToolThreadStartRequestContract).sort(),
-    ["apply", "assertAfter", "assertBefore", "find", "name"]
-  );
-  assert.equal(dynamicToolThreadStartRequestContract.name, "dynamic-tool-thread-start-request");
 });
 
 test("patchLinuxOpenTargetsSource reports contract name on upstream drift", () => {
@@ -444,164 +410,4 @@ test("hasUnguardedOwlFeatureBindingSource detects mixed patched and unpatched he
   ].join(";");
 
   assert.equal(hasUnguardedOwlFeatureBindingSource(mixedSource), true);
-});
-
-test("patchDynamicToolStartResponseSource normalizes desktop thread-start dynamic tools", () => {
-  const source = [
-    "class Manager{constructor(){this.pendingDynamicToolsForThreadStartRequests=new Map}send(t){this.pendingDynamicToolsForThreadStartRequests.set(`req`,{originId:1,timeout:null,resolve:e=>{globalThis.result=e}});this.handleDynamicToolsForThreadStartResponse({id:1},{requestId:`req`,dynamicTools:t})}handleDynamicToolsForThreadStartResponse(e,t){let n=this.pendingDynamicToolsForThreadStartRequests.get(t.requestId);if(!n||n.originId!==e.id)return;this.pendingDynamicToolsForThreadStartRequests.delete(t.requestId),clearTimeout(n.timeout),n.resolve(t.dynamicTools)}}",
-    "let manager=new Manager;",
-    "manager.send([{type:`namespace`,name:`codex_app`,tools:[{type:`function`,name:`good`,inputSchema:{type:`object`}},{type:`function`,name:`snake`,input_schema:{type:`object`}},{type:`function`,name:`params`,parameters:{type:`object`}},{type:`function`,name:`bad`},{type:`other`,name:`untouched`}]}]);"
-  ].join("");
-
-  const patched = patchDynamicToolStartResponseSource(source);
-  const context = {
-    clearTimeout,
-    globalThis: {}
-  };
-
-  vm.runInNewContext(patched, context);
-
-  const tools = context.globalThis.result[0].tools;
-
-  assert.equal(hasUnguardedDynamicToolStartResponseSource(patched), false);
-  assert.equal(JSON.stringify(tools.map(tool => tool.name)), JSON.stringify(["good", "snake", "params", "untouched"]));
-  assert.equal(tools.filter(tool => tool.type === "function").every(tool => tool.inputSchema?.type === "object"), true);
-});
-
-test("patchDynamicToolStartResponseSource is idempotent", () => {
-  const source = "class Manager{handleDynamicToolsForThreadStartResponse(e,t){let n=this.pendingDynamicToolsForThreadStartRequests.get(t.requestId);if(!n||n.originId!==e.id)return;this.pendingDynamicToolsForThreadStartRequests.delete(t.requestId),clearTimeout(n.timeout),n.resolve(t.dynamicTools)}}";
-  const patched = patchDynamicToolStartResponseSource(source);
-
-  assert.equal(patchDynamicToolStartResponseSource(patched), patched);
-});
-
-test("hasUnguardedDynamicToolStartResponseSource detects unpatched desktop resolver", () => {
-  const source = "class Manager{handleDynamicToolsForThreadStartResponse(e,t){let n=this.pendingDynamicToolsForThreadStartRequests.get(t.requestId);if(!n||n.originId!==e.id)return;this.pendingDynamicToolsForThreadStartRequests.delete(t.requestId),clearTimeout(n.timeout),n.resolve(t.dynamicTools)}}";
-
-  assert.equal(hasUnguardedDynamicToolStartResponseSource(source), true);
-});
-
-test("patchDynamicToolThreadStartBridgeSource normalizes final Electron bridge requests", async () => {
-  const source = [
-    "class Bridge{constructor(){this.requests=[]}getAppServerConnection(){return{handleClientRequest:async(e,t)=>{this.requests.push(t)},handlePrewarmThreadStart:async(e,t)=>{this.requests.push(t)}}}",
-    "async handleMessage(e,n){switch(n.type){case`mcp-request`:{let t=n.request;await this.getAppServerConnection(n.hostId).handleClientRequest({},t);break}case`thread-prewarm-start`:await this.getAppServerConnection(n.hostId).handlePrewarmThreadStart({},n.request);break}}}",
-    "let dynamicTools=[{type:`namespace`,name:`codex_app`,tools:[{type:`function`,name:`good`,inputSchema:{type:`object`}},{name:`plainSnake`,input_schema:{type:`object`}},{name:`plainParams`,parameters:{type:`object`}},{type:`function`,name:`bad`},{type:`other`,id:`untouched`}]},{name:`top`,parameters:{type:`object`}},{name:`topBad`}];",
-    "globalThis.bridge=new Bridge;await globalThis.bridge.handleMessage(null,{type:`mcp-request`,hostId:`local`,request:{id:`1`,method:`thread/start`,params:{dynamicTools}}});await globalThis.bridge.handleMessage(null,{type:`thread-prewarm-start`,hostId:`local`,request:{id:`2`,method:`thread/start`,params:{dynamicTools}}});"
-  ].join("");
-
-  const patched = patchDynamicToolThreadStartBridgeSource(source);
-  const context = {
-    globalThis: {}
-  };
-
-  await vm.runInNewContext(`(async()=>{${patched}})()`, context);
-
-  const [normal, prewarm] = context.globalThis.bridge.requests;
-  const tools = normal.params.dynamicTools;
-
-  assert.equal(hasUnguardedDynamicToolThreadStartBridgeSource(patched), false);
-  assert.equal(JSON.stringify(tools.map(tool => tool.name)), JSON.stringify(["good", "plainSnake", "plainParams", "bad", "top", "topBad"]));
-  assert.equal(tools.every(tool => tool.type === "function"), true);
-  assert.equal(tools.every(tool => tool.inputSchema?.type === "object"), true);
-  assert.equal(tools.slice(0, 4).every(tool => tool.namespace === "codex_app"), true);
-  assert.equal(tools.slice(4).every(tool => tool.namespace == null), true);
-  assert.deepEqual(prewarm.params.dynamicTools, tools);
-});
-
-test("patchDynamicToolThreadStartBridgeSource is idempotent", () => {
-  const source = "class Bridge{getAppServerConnection(){return{handleClientRequest(){},handlePrewarmThreadStart(){}}}async handleMessage(e,n){switch(n.type){case`mcp-request`:{let t=n.request;await this.getAppServerConnection(n.hostId).handleClientRequest({},t);break}case`thread-prewarm-start`:await this.getAppServerConnection(n.hostId).handlePrewarmThreadStart({},n.request);break}}}";
-  const patched = patchDynamicToolThreadStartBridgeSource(source);
-
-  assert.equal(patchDynamicToolThreadStartBridgeSource(patched), patched);
-});
-
-test("hasUnguardedDynamicToolThreadStartBridgeSource detects raw Electron bridge requests", () => {
-  const source = "class Bridge{getAppServerConnection(){return{handleClientRequest(){},handlePrewarmThreadStart(){}}}async handleMessage(e,n){switch(n.type){case`mcp-request`:{let t=n.request;await this.getAppServerConnection(n.hostId).handleClientRequest({},t);break}case`thread-prewarm-start`:await this.getAppServerConnection(n.hostId).handlePrewarmThreadStart({},n.request);break}}}";
-
-  assert.equal(hasUnguardedDynamicToolThreadStartBridgeSource(source), true);
-});
-
-test("patchDynamicToolSchemaContractSource normalizes thread-start dynamic tool schemas", async () => {
-  const source = [
-    "var yr=`codex_app`,br=new Set;",
-    "var good={name:`good`,inputSchema:{type:`object`,properties:{},additionalProperties:!1}};",
-    "var snake={name:`snake`,input_schema:{type:`object`,properties:{value:{type:`string`}}}};",
-    "var parameters={name:`parameters`,parameters:{type:`object`,properties:{count:{type:`number`}}}};",
-    "var bad={name:`bad`};",
-    "async function xr(){return[{type:`namespace`,name:yr,description:`Tools provided by the Codex app.`,tools:[good,snake,parameters,bad].map(e=>({type:`function`,...e,...br.has(e.name)?{}:{deferLoading:!0}}))}]}",
-    "globalThis.result=await xr();"
-  ].join("");
-
-  const patched = patchDynamicToolSchemaContractSource(source);
-  const context = {
-    globalThis: {}
-  };
-
-  await vm.runInNewContext(`(async()=>{${patched}})()`, context);
-
-  const tools = context.globalThis.result[0].tools;
-
-  assert.equal(hasUnguardedDynamicToolSchemaContractSource(patched), false);
-  assert.equal(JSON.stringify(tools.map(tool => tool.name)), JSON.stringify(["good", "snake", "parameters"]));
-  assert.equal(tools.every(tool => tool.inputSchema?.type === "object"), true);
-  assert.equal(tools.every(tool => tool.deferLoading === true), true);
-});
-
-test("patchDynamicToolThreadStartRequestSource normalizes final thread/start params", () => {
-  const source = [
-    "class Client{constructor(){this.requestPromises=new Map;this.hostId=`local`;this.dispatchMessage=(type,payload)=>{globalThis.sent={type,payload}};this.requestLifecycleListeners=[]}",
-    "createRequest(e,t,n){let r=`req`,i=n?.timeoutMs??0,a=null,o=this.requestPromises.size,s=Date.now(),c=Promise.resolve();return console.debug(`mcp_request_enqueued`),{request:{id:r,method:e,params:t},promise:c}}",
-    "sendRequest(e,t,n){let{request:r,promise:i}=this.createRequest(e,t,n);this.dispatchMessage(`mcp-request`,{request:r,hostId:this.hostId});return i}}",
-    "new Client().sendRequest(`thread/start`,{dynamicTools:[{type:`namespace`,name:`codex_app`,tools:[{type:`function`,name:`good`,inputSchema:{type:`object`}},{type:`function`,name:`snake`,input_schema:{type:`object`}},{type:`function`,name:`params`,parameters:{type:`object`}},{type:`function`,name:`bad`},{type:`other`,name:`untouched`}]}]});"
-  ].join("");
-
-  const patched = patchDynamicToolThreadStartRequestSource(source);
-  const context = {
-    console: { debug() {} },
-    globalThis: {}
-  };
-
-  vm.runInNewContext(patched, context);
-
-  const tools = context.globalThis.sent.payload.request.params.dynamicTools;
-
-  assert.equal(hasUnguardedDynamicToolThreadStartRequestSource(patched), false);
-  assert.equal(JSON.stringify(tools.map(tool => tool.name)), JSON.stringify(["good", "snake", "params", "bad"]));
-  assert.equal(tools.every(tool => tool.type === "function"), true);
-  assert.equal(tools.every(tool => tool.inputSchema?.type === "object"), true);
-  assert.equal(tools.every(tool => tool.namespace === "codex_app"), true);
-});
-
-test("patchDynamicToolThreadStartRequestSource is idempotent", () => {
-  const source = "class Client{createRequest(e,t,n){let r=`req`,c=Promise.resolve();return console.debug(`mcp_request_enqueued`),{request:{id:r,method:e,params:t},promise:c}}}new Client().createRequest(`thread/start`,{},{});";
-  const patched = patchDynamicToolThreadStartRequestSource(source);
-
-  assert.equal(patchDynamicToolThreadStartRequestSource(patched), patched);
-});
-
-test("hasUnguardedDynamicToolThreadStartRequestSource detects raw thread/start params", () => {
-  const source = "class Client{createRequest(e,t,n){let r=`req`,c=Promise.resolve();return console.debug(`mcp_request_enqueued`),{request:{id:r,method:e,params:t},promise:c}}}new Client().createRequest(`thread/start`,{},{});";
-
-  assert.equal(hasUnguardedDynamicToolThreadStartRequestSource(source), true);
-});
-
-test("patchDynamicToolSchemaContractSource is idempotent", () => {
-  const source = [
-    "var yr=`codex_app`,br=new Set;",
-    "var good={name:`good`,inputSchema:{type:`object`,properties:{},additionalProperties:!1}};",
-    "async function xr(){return[{type:`namespace`,name:yr,description:`Tools provided by the Codex app.`,tools:[good].map(e=>({type:`function`,...e,...br.has(e.name)?{}:{deferLoading:!0}}))}]}"
-  ].join("");
-  const patched = patchDynamicToolSchemaContractSource(source);
-
-  assert.equal(patchDynamicToolSchemaContractSource(patched), patched);
-});
-
-test("hasUnguardedDynamicToolSchemaContractSource detects unpatched schema mapper", () => {
-  const source = [
-    "var yr=`codex_app`,br=new Set;",
-    "var good={name:`good`,inputSchema:{type:`object`,properties:{},additionalProperties:!1}};",
-    "async function xr(){return[{type:`namespace`,name:yr,description:`Tools provided by the Codex app.`,tools:[good].map(e=>({type:`function`,...e,...br.has(e.name)?{}:{deferLoading:!0}}))}]}"
-  ].join("");
-
-  assert.equal(hasUnguardedDynamicToolSchemaContractSource(source), true);
 });


### PR DESCRIPTION
## Summary

- preserve the upstream Electron main entry instead of forcing the removed `.vite/build/bootstrap.js`
- align the bundled Linux Codex runtime payloads with the 26.707 app by updating to `0.144.0-alpha.4`
- replace both Darwin `codex` and `codex-code-mode-host` resources with their Linux x64 package counterparts
- remove the obsolete Linux dynamic-tool request rewriting and defer protocol compatibility to the matching upstream runtime

## Root cause

Codex 26.707 changed `package.json.main` to `.vite/build/early-bootstrap.js`, while the electron-builder configuration forced the old entry.

The Linux publisher also remained pinned to Codex 0.140.0 and copied the newly added Darwin code-mode host into Linux artifacts.

After updating the runtime, the old 0.140-era compatibility patches transformed canonical requests into a hybrid canonical/legacy format rejected by Codex 0.144.

## Impact

This restores prod and beta 26.707 builds, ships native Linux runtime payloads, exposes the 5.6 model catalog, and passes upstream dynamic-tool requests through unchanged.

The packaged runtime accepts canonical and legacy requests independently and rejects malformed hybrid requests. Runtime downloads remain protected by the existing SHA-256 verification.

## Validation

- `npm test` - 95/95 passed in a clean worktree
- prod and beta 26.707 builds completed successfully
- all artifact, desktop, browser, focusable, and Linux native-payload smoke checks passed for both channels
- packaged app-server smoke verified canonical success, legacy success, and hybrid rejection
- prod and beta bundled CLI versions: `codex-cli 0.144.0-alpha.4`
- prod and beta `model/list` include `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`
- generated ASAR files contain none of the removed Linux dynamic-tool patch markers
- installed `codex-app-unofficial 26.707.31428_launcher.34-3` locally and completed a real App UI task with 5.6 Luna; it returned `E2E_DYNAMIC_TOOLS_OK` without renderer errors, protocol errors, or workspace changes

Closes #34
Closes #35
Closes #37
Closes #38
Closes #39
