### PR TITLE
fix(webstrap): stub Sparkle query params in web shell

### DIFF
--- a/runtime/webstrap/server.mjs
+++ b/runtime/webstrap/server.mjs
@@ -532,6 +532,7 @@ const appUpdateState = {
 const appHostMain = {
   services: {
     appUpdates: {
+      setSparkleQueryParams() {},
       installUpdate() {},
       stateChanged(callback) {
         appUpdateSubscribers.add(callback);

--- a/test/web-assets.test.mjs
+++ b/test/web-assets.test.mjs
@@ -121,6 +121,15 @@ test("createAppHostModuleBody resolves RPC peer constructor semantically", () =>
   assert.doesNotMatch(body, /import \{ E as createRpcPeer \}/);
 });
 
+test("createAppHostModuleBody exposes Sparkle query params RPC", () => {
+  const body = createAppHostModuleBody(
+    "/tmp/codex-web/webview/assets/rpc-new.js",
+    "/tmp/codex-web/webview"
+  );
+
+  assert.match(body, /appUpdates:\s*\{[\s\S]*?setSparkleQueryParams\(\)\s*\{\s*\}/);
+});
+
 test("findAppHostRpcModulePath accepts upstream rpc facade layout", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-app-linux-rpc-assets-"));
   const assetsDir = path.join(root, "assets");


### PR DESCRIPTION
## Summary

- Add a no-op `appUpdates.setSparkleQueryParams()` implementation to the Linux Web Shell app-host RPC.
- Add regression coverage for the generated app-host RPC surface.
- Fixes #51.

## Root cause

Upstream prod build `26.715.21425` (build `5488`) calls:

```js
ki.appUpdates?.setSparkleQueryParams({ planType: o })
```

The Linux Web Shell exposed `appUpdates`, but did not implement
`setSparkleQueryParams`. Optional chaining guarded only `appUpdates`, so the
missing method caused:

```text
TypeError: ki.appUpdates?.setSparkleQueryParams is not a function
```

## Behavior

Linux Web Shell does not have a native Sparkle updater. The new method is
therefore an intentional no-op that preserves RPC compatibility without
changing update behavior.

## Validation

- `node --test test/web-assets.test.mjs` — 12 passed
- `node --test test/*.test.mjs` — 96 passed
- Cached prod build `26.715.21425` / build `5488` smoke — all checks passed
- Full prod canary build — 11/11 checks passed, including `web-browser-shell`

`npm test` also discovers ignored generated tests under `dist/` and `stage/`;
those contain six pre-existing missing generated server-module failures. The
controlled repository test suite passes.
